### PR TITLE
added loop helper and fix hello world gas

### DIFF
--- a/NFT/hardhat.config.js
+++ b/NFT/hardhat.config.js
@@ -30,5 +30,8 @@ module.exports = {
       },
       chainId: 595,
     },
+  },  
+  mocha: {
+    timeout: 300000
   }
 };

--- a/NFT/hardhat.config.js
+++ b/NFT/hardhat.config.js
@@ -30,8 +30,5 @@ module.exports = {
       },
       chainId: 595,
     },
-  },  
-  mocha: {
-    timeout: 300000
-  }
+  }  
 };

--- a/echo/hardhat.config.js
+++ b/echo/hardhat.config.js
@@ -30,5 +30,8 @@ module.exports = {
       },
       chainId: 595,
     },
+  },  
+  mocha: {
+    timeout: 300000
   }
 };

--- a/echo/hardhat.config.js
+++ b/echo/hardhat.config.js
@@ -30,8 +30,5 @@ module.exports = {
       },
       chainId: 595,
     },
-  },  
-  mocha: {
-    timeout: 300000
-  }
+  }  
 };

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -108,7 +108,31 @@ Let's break this configuration down a bit:
 connected to our local development network.
 - `mnemonic` used in the `accounts` section represents derivation mnemonic used to derive the
 default development accounts of the local development network.
+- `path` used in the `accounts` section defines the account derivation path to be used with the
+given mnemonic
 - `cahinId` of `595` is the default chain ID of the local development network.
+
+In addition to the local development network, we can also add the network configuration for the
+public development network. Most of the parameters are the same as for the local development network
+(unless you plan on using your own development accounts). The only change that we need to do is to
+change the URL of the network from `http://127.0.0.1:3330` to `https://tc7-eth.aca-dev.network`. The
+following should be added to the `network`  section of the `hardhat.config.js`:
+
+```
+    mandalaPubDev: {
+      url: 'https://tc7-eth.aca-dev.network',
+      accounts: {
+        mnemonic: 'fox sight canyon orphan hotel grow hedgehog build bless august weather swarm',
+        path: "m/44'/60'/0'/0",
+      },
+      chainId: 595,
+    },
+```
+
+**NOTE: If you are referencing the `hardhat.config.js` present in this tutorial, you may have
+noticed another network called `mandalaCI`. This network is present within the tutorials, so
+that we can verify the expected behaviour of the Acala EVM+ and you don't need to include it
+within your project to be able to develop, test or deploy your project.**
 
 This concludes the configuration of Hardhat. Now we can move on to the smart contract development.
 
@@ -130,8 +154,15 @@ This concludes the configuration of Hardhat. Now we can move on to the smart con
                 path: "m/44'/60'/0'/0",
             },
             chainId: 595,
-            gasPrice: 429496729610000, // storage_limit = 100000, validUntil = 10000, 100000 << 32 | 10000
             },
+          mandalaPubDev: {
+            url: 'https://tc7-eth.aca-dev.network',
+            accounts: {
+              mnemonic: 'fox sight canyon orphan hotel grow hedgehog build bless august weather swarm',
+              path: "m/44'/60'/0'/0",
+            },
+            chainId: 595,
+          },
         }
     };
 </details>
@@ -206,11 +237,12 @@ describe("HelloWorld contract", async function () {
 
 Within the `describe` block, we set the `ethParams` from the `eth-providers` dependency (we won't be
 using all of them, but they are added to the example for reference), then we first get the contract
-factory and then deploy it. Once the smart contract is deployed, we can call the `helloWorld()`
-function, that was automatically generated because we made the `helloWorld` variable public and
-store the result. We compare that result to the `Hello World!` string and if everything is in order,
-our test should pass. Adding these steps to the `describe` block, requires us to place them within
-the `it` block, which we in turn place within the `describe` block:
+factory and then deploy it, passing the transaction parameters within the deployment transaction.
+Once the smart contract is deployed, we can call the `helloWorld()` function, that was automatically
+generated because we made the `helloWorld` variable public and store the result. We compare that
+result to the `Hello World!` string and if everything is in order, our test should pass. Adding
+these steps to the `describe` block, requires us to place them within the `it` block, which we in
+turn place within the `describe` block:
 
 ```js
     it("returns the right value after the contract is deployed", async function () {
@@ -224,7 +256,10 @@ the `it` block, which we in turn place within the `describe` block:
 
         const HelloWorld = await ethers.getContractFactory("HelloWorld");
 
-        const instance = await HelloWorld.deploy();
+        const instance = await HelloWorld.deploy({
+                gasPrice: ethParams.txGasPrice,
+                gasLimit: ethParams.txGasLimit
+        });
 
         const value = await instance.helloWorld();
 
@@ -256,7 +291,8 @@ With that, our test is ready to be run.
             const HelloWorld = await ethers.getContractFactory("HelloWorld");
             
             const instance = await HelloWorld.deploy({
-                    gasPrice: ethParams.txGasPrice
+                    gasPrice: ethParams.txGasPrice,
+                    gasLimit: ethParams.txGasLimit
             });
 
             const value = await instance.helloWorld();
@@ -267,19 +303,152 @@ With that, our test is ready to be run.
 
 </details>
 
-To be able to run the tests, we will add two additional scripts to the `package.json`. One to run
-the test in the Hardhat's built-in network (this is a very fast option) and one to run the tests on
-a local development network. This way you can verify the expected behaviour on Acala EVM+. Add these
-two lines to the `scripts` section of your `package.json`:
+To be able to run the tests, we will add three additional scripts to the `package.json`. One to run
+the test in the Hardhat's built-in network (this is a very fast option), one to run the tests on
+a local development network and one to run the tests in the public test network. This way you can
+verify the expected behaviour on Acala EVM+. Add these three lines to the `scripts` section of your
+`package.json`:
 
 ```json
     "test": "hardhat test",
-    "test-mandala": "hardhat test --network mandala"
+    "test-mandala": "hardhat test --network mandala",
+    "test-mandala:pubDev": "hardhat test --network mandalaPubDev"
 ```
 
-As you can see, the `test-mandala` script differs from `test` script in the `--network` flag which
-we use to tell Hardhat to use the `mandala` network configuration from `hardhat.config.js` that we
-added in the beginning of this tutorial.
+As you can see, the `test-mandala` and `test-mandala:pubDev` script differ from `test` script in
+the `--network` flag which we use to tell Hardhat to use the `mandala` or `mandalaPubDev` network
+configuration from `hardhat.config.js` that we added in the beginning of this tutorial.
+
+**NOTE: If the `--instant-sealing` flag is used in the local development network, the block
+generation has to be forced and the tests might fail because of the package manager waiting for
+new blocks. To avoid test failure, a helper `loop.js` method is added to the `test/` directory.**
+
+Usage of `--instant-sealing` flag in a development network is beneficial, as it decreases the time
+needed to test out the behaviour of the project, but it also requires the `loop.js` helper, which
+forces the block creation. To add `loop.js` helper, run the following comand in the root of your
+project:
+
+```shell
+touch test/loop.js
+```
+
+The `loop.js` helper will continuously deploy the `HelloWorld` smart contract and force the
+generation of the new blocks. At the beginning of the helper we import the
+`calcEthereumTransactionParams` from `@acala-network/eth-providers` and define the transaction
+parameter constants that the deploy transaction will use. Additionaly we define a `sleep()`
+function, that we will use to ensure that block generation is forced every 2 seconds:
+
+```js
+const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
+
+const txFeePerGas = '199999946752';
+const storageByteDeposit = '100000000000000';
+
+const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
+```
+
+Now we are ready to define the `loop()` function and call it. Within the definition we also
+ensure that interval for function execution is set for 2 seconds:
+
+```js
+const loop = async (interval = 2000) => {
+
+};
+
+loop();
+```
+
+Transaction paramteres are configured at the top of the `loop()`  function definition. Below we
+log the start of the loop to the console and define a `count` variable, which will be used to
+keep track of how many times the function has forced a block generation:
+
+```js
+  const ethParams = calcEthereumTransactionParams({
+    gasLimit: '2100001',
+    validUntil: '360001',
+    storageLimit: '64001',
+    txFeePerGas,
+    storageByteDeposit
+  });
+
+  console.log('Started the infinite HelloWorld deployment loop!');
+
+  let count = 0;
+```
+
+Now that the setup for the continuous deployment of the smart contract is set up, we can add a
+`while` loop to constantly deploy the smart contract. Within it we use the `interval` variable
+to ensure that the nex step of the loop is executed 2 seconds after the previous one has ended,
+we assign the `HelloWorld` contract to the contract factory and deploy it using the deployment
+parameters we defined in the beginning. Before finishing the loop, we output the current number
+of times the block generation was forced usiung this script:
+
+```js
+  while (true) {
+    await sleep(interval);
+    const HelloWorld = await ethers.getContractFactory('HelloWorld');
+    await HelloWorld.deploy({
+      gasPrice: ethParams.txGasPrice,
+      gasLimit: ethParams.txGasLimit
+    });
+
+    console.log(`Current number of HelloWorld instances: ${++count}`);
+  }
+```
+
+<details>
+    <summary>Your test/loop.js should look like this:</summary>
+
+    const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
+
+    const txFeePerGas = '199999946752';
+    const storageByteDeposit = '100000000000000';
+
+    const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
+
+    const loop = async (interval = 2000) => {
+      const ethParams = calcEthereumTransactionParams({
+        gasLimit: '2100001',
+        validUntil: '360001',
+        storageLimit: '64001',
+        txFeePerGas,
+        storageByteDeposit
+      });
+
+      console.log('Started the infinite HelloWorld deployment loop!');
+
+      let count = 0;
+
+      while (true) {
+        await sleep(interval);
+        const HelloWorld = await ethers.getContractFactory('HelloWorld');
+        await HelloWorld.deploy({
+          gasPrice: ethParams.txGasPrice,
+          gasLimit: ethParams.txGasLimit
+        });
+
+        console.log(`Current number of HelloWorld instances: ${++count}`);
+      }
+    };
+
+    loop();
+
+</details>
+
+The last thing we need to do with the `loop.js` helper, is to add it's execution to `scripts`
+section of our `package.json`. Since we will only be using it in a local development network
+that uses the `--instant-sealing` flag, we only need to add one execution script:
+
+```json
+    "loop": "hardhat run test/loop.js --network mandala"
+```
+
+This has to be run in its own terminal only when testing and deploying to a local development
+network that uses `-instant-sealing` flag with:
+
+```bash
+yarn loop
+```
 
 When you run the test with (for example) `yarn test`, your tests should pass with the following
 output:
@@ -351,7 +520,7 @@ development:
 Our deploy script will reside in the definition (`async function main()`). First we will get
 the address of the account which will be used to deploy the smart contract. Then we get the
 `HelloWorld.sol` to the contract factory and deploy it, while passing the transaction parameters
-defined at the beginning of the `main()` funciton and assign the deployed smart contract to the
+defined at the beginning of the `main()` function and assign the deployed smart contract to the
 `instance` variable, which we ensure that is deployed. Assigning the `instance` variable is optional
 and is only done, so that we can output the value returned by the `helloWorld()` getter to the
 terminal. We do it by calling `helloWorld()` from instance and outputting the result using
@@ -362,7 +531,8 @@ terminal. We do it by calling `helloWorld()` from instance and outputting the re
 
   const HelloWorld = await ethers.getContractFactory("HelloWorld");
   const instance = await HelloWorld.deploy({
-    gasPrice: ethParams.txGasPrice
+    gasPrice: ethParams.txGasPrice,
+    gasLimit: ethParams.txGasLimit,
   });
 
   await instance.deployed();
@@ -393,7 +563,8 @@ terminal. We do it by calling `helloWorld()` from instance and outputting the re
 
       const HelloWorld = await ethers.getContractFactory("HelloWorld");
       const instance = await HelloWorld.deploy({
-        gasPrice: ethParams.txGasPrice
+        gasPrice: ethParams.txGasPrice,
+        gasLimit: ethParams.txGasLimit,
       });
 
       await instance.deployed();
@@ -412,14 +583,16 @@ terminal. We do it by calling `helloWorld()` from instance and outputting the re
 
 </details>
 
-All that is left to do, is update the `scripts` section in the `package.json` with the `deploy` and
-`deploy-mandala` scripts. Once again, we are adding two scripts, so that we can deploy to the
-built-in network as well as the local development network. To add theses two scripts to your
-project, place the following two lines within `scripts` section of the `package.json`:
+All that is left to do, is update the `scripts` section in the `package.json` with the `deploy`,
+`deploy-mandala` and `deploy-mandala:pubDev` scripts. Once again, we are adding three scripts,
+so that we can deploy to the built-in network as well as the local development network and to
+the public test network. To add these scripts to your project, place the following three lines
+within `scripts` section of the `package.json`:
 
 ```json
     "deploy": "hardhat run scripts/deploy.js",
-    "deploy-mandala": "TS_NODE_TRANSPILE_ONLY=true hardhat run scripts/deploy.ts --network mandala"
+    "deploy-mandala": "hardhat run scripts/deploy.js --network mandala",
+    "deploy-mandala:pubDev": "hardhat run scripts/deploy.js --network mandalaPubDev",
 ```
 
 Running the `yarn deploy` script should return the following output:
@@ -439,5 +612,6 @@ Stored value: Hello World!
 
 We have initiated an empty Hardhat project and configured it to work with Acala EVM+. We added a
 `HelloWorld.sol` smart contract, that can be compiled using `yarn build`, and wrote tests for it,
-which can be run using `yarn test` or `yarn test-mandala`. Additionally we added the deploy script,
-that can be run using `yarn deploy` or `yarn deploy-mandala`.
+which can be run using `yarn test`, `yarn test-mandala` or `yarn test-mandala:pubDev`.
+Additionally we added the deploy script, that can be run using `yarn deploy`, `yarn deploy-mandala`
+or `yarn deploy-mandala:pubDev`.

--- a/hello-world/hardhat.config.js
+++ b/hello-world/hardhat.config.js
@@ -30,5 +30,8 @@ module.exports = {
       },
       chainId: 595,
     },
+  },  
+  mocha: {
+    timeout: 300000
   }
 };

--- a/hello-world/hardhat.config.js
+++ b/hello-world/hardhat.config.js
@@ -30,8 +30,5 @@ module.exports = {
       },
       chainId: 595,
     },
-  },  
-  mocha: {
-    timeout: 300000
-  }
+  }  
 };

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -16,7 +16,9 @@
     "deploy": "hardhat run scripts/deploy.js",
     "deploy-mandala": "hardhat run scripts/deploy.js --network mandala",
     "deploy-mandala:pubDev": "hardhat run scripts/deploy.js --network mandalaPubDev",
-    "deploy-mandala:CI": "hardhat run scripts/deploy.js --network mandalaCI"
+    "deploy-mandala:CI": "hardhat run scripts/deploy.js --network mandalaCI",
+    "loop": "hardhat run test/loop.js --network mandala",
+    "loop:CI": "hardhat run test/loop.js --network mandalaCI"
   },
   "devDependencies": {
     "@acala-network/eth-providers": "^2.1.6",

--- a/hello-world/scripts/deploy.js
+++ b/hello-world/scripts/deploy.js
@@ -20,7 +20,8 @@ async function main() {
 
   const HelloWorld = await ethers.getContractFactory("HelloWorld");
   const instance = await HelloWorld.deploy({
-    gasPrice: ethParams.txGasPrice
+    gasPrice: ethParams.txGasPrice,
+    gasLimit: ethParams.txGasLimit,
   });
 
   await instance.deployed();

--- a/hello-world/test/HelloWorld.js
+++ b/hello-world/test/HelloWorld.js
@@ -17,7 +17,8 @@ describe("HelloWorld contract", async function () {
         const HelloWorld = await ethers.getContractFactory("HelloWorld");
         
         const instance = await HelloWorld.deploy({
-                gasPrice: ethParams.txGasPrice
+                gasPrice: ethParams.txGasPrice,
+                gasLimit: ethParams.txGasLimit
         });
 
         const value = await instance.helloWorld();

--- a/hello-world/test/loop.js
+++ b/hello-world/test/loop.js
@@ -5,8 +5,6 @@ const storageByteDeposit = '100000000000000';
 
 const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
 
-// this is a helper method to keep feeding tx to node
-// usedful when running node with --instant-sealing
 const loop = async (interval = 2000) => {
   const ethParams = calcEthereumTransactionParams({
     gasLimit: '2100001',
@@ -17,7 +15,9 @@ const loop = async (interval = 2000) => {
   });
 
   console.log('Started the infinite HelloWorld deployment loop!');
+
   let count = 0;
+
   while (true) {
     await sleep(interval);
     const HelloWorld = await ethers.getContractFactory('HelloWorld');

--- a/hello-world/test/loop.js
+++ b/hello-world/test/loop.js
@@ -7,7 +7,7 @@ const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
 
 // this is a helper method to keep feeding tx to node
 // usedful when running node with --instant-sealing
-const loop = async (interval = 8000) => {
+const loop = async (interval = 2000) => {
   const ethParams = calcEthereumTransactionParams({
     gasLimit: '2100001',
     validUntil: '360001',

--- a/hello-world/test/loop.js
+++ b/hello-world/test/loop.js
@@ -1,0 +1,31 @@
+const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
+
+const txFeePerGas = '199999946752';
+const storageByteDeposit = '100000000000000';
+
+const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
+
+const loop = async (interval = 8000) => {
+  const ethParams = calcEthereumTransactionParams({
+    gasLimit: '2100001',
+    validUntil: '360001',
+    storageLimit: '64001',
+    txFeePerGas,
+    storageByteDeposit
+  });
+
+  console.log('infinite hello world started!');
+  let count = 0;
+  while (true) {
+    await sleep(interval);
+    const HelloWorld = await ethers.getContractFactory('HelloWorld');
+    await HelloWorld.deploy({
+      gasPrice: ethParams.txGasPrice,
+      gasLimit: ethParams.txGasLimit
+    });
+
+    console.log(`infinite hello world count: ${++count}`);
+  }
+};
+
+loop();

--- a/hello-world/test/loop.js
+++ b/hello-world/test/loop.js
@@ -5,6 +5,8 @@ const storageByteDeposit = '100000000000000';
 
 const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
 
+// this is a helper method to keep feeding tx to node
+// usedful when running node with --instant-sealing
 const loop = async (interval = 8000) => {
   const ethParams = calcEthereumTransactionParams({
     gasLimit: '2100001',

--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ test_all() {
     "hello-world"
     "echo"
     "token"
-    "nft"
+    "NFT"
   )
 
   ROOT=$(pwd)

--- a/token/hardhat.config.js
+++ b/token/hardhat.config.js
@@ -30,5 +30,8 @@ module.exports = {
       },
       chainId: 595,
     },
+  },  
+  mocha: {
+    timeout: 300000
   }
 };

--- a/token/hardhat.config.js
+++ b/token/hardhat.config.js
@@ -30,8 +30,5 @@ module.exports = {
       },
       chainId: 595,
     },
-  },  
-  mocha: {
-    timeout: 300000
-  }
+  }  
 };


### PR DESCRIPTION
## Change
- imported the loop helper similar to this https://github.com/AcalaNetwork/bodhi.js/blob/master/examples/hardhat/test/loop.ts. This will be used by the CI
- as of mandala 2.1.0, we need to calculate `gasPrice and gasLimit` and specify them when calling `contract.deploy()`, I fixed gas for hello world, would be mind fixing the others? Thanks!

## Test
using mandala 2.1.0, `yarn test-mandala` and `yarn deploy-mandala` works, previously it will throw gas error, something like 

```
$ hardhat run scripts/deploy.js --network mandala
Deploying contracts with the account: 0x75E480dB528101a381Ce68544611C169Ad7EB342
Account balance: 9999984290070863124000000
ProviderError: invalid gasLimit or gasPrice (txGasLimit="200143", txGasPrice="200786445289", gasLimit="-31831857", validUntil="360030", storageLimit="64064", storageDepositPerByte="100000000000000", txFeePerGas="199999946752", code=INVALID_ARGUMENT, version=bodhi.js/providers/2.1.7)
```