### PR TITLE
Remove build script from PrecompiledToken

### DIFF
--- a/precompiled-token/package.json
+++ b/precompiled-token/package.json
@@ -12,7 +12,6 @@
     "test-mandala": "hardhat test test/PrecompiledToken.js --network mandala",
     "test-mandala:pubDev": "hardhat test test/PrecompiledToken.js --network mandalaPubDev",
     "test-mandala:CI": "hardhat test --network mandalaCI",
-    "build": "hardhat compile",
     "get-info": "hardhat run scripts/getACAinfo.js",
     "get-info-mandala": "hardhat run scripts/getACAinfo.js --network mandala",
     "get-info-mandala:pubDev": "hardhat run scripts/getACAinfo.js --network mandalaPubDev",


### PR DESCRIPTION
Removed the build script from package.js in the PrecompiledToken
tutorial as there is no smart contract that this script could compile.