### PR TITLE
Update validUntil values

### DIFF
--- a/NFT/README.md
+++ b/NFT/README.md
@@ -151,7 +151,7 @@ const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 describe("NFT contract", async function () {
         const ethParams = calcEthereumTransactionParams({
                 gasLimit: '21000010',
-                validUntil: '360001',
+                validUntil: '3600010',
                 storageLimit: '640010',
                 txFeePerGas,
                 storageByteDeposit
@@ -592,7 +592,7 @@ With that, our test is ready to be run.
         describe("NFT contract", async function () {
                 const ethParams = calcEthereumTransactionParams({
                         gasLimit: '21000010',
-                        validUntil: '360001',
+                        validUntil: '3600010',
                         storageLimit: '640010',
                         txFeePerGas,
                         storageByteDeposit
@@ -971,7 +971,7 @@ we output the URI of the newly minted NFT:
 ```js
   const ethParams = calcEthereumTransactionParams({
     gasLimit: '21000010',
-    validUntil: '360001',
+    validUntil: '3600010',
     storageLimit: '640010',
     txFeePerGas,
     storageByteDeposit
@@ -1009,7 +1009,7 @@ we output the URI of the newly minted NFT:
         async function main() {
                 const ethParams = calcEthereumTransactionParams({
                         gasLimit: '21000010',
-                        validUntil: '360001',
+                        validUntil: '3600010',
                         storageLimit: '640010',
                         txFeePerGas,
                         storageByteDeposit

--- a/NFT/scripts/deploy.js
+++ b/NFT/scripts/deploy.js
@@ -6,7 +6,7 @@ const storageByteDeposit = '100000000000000';
 async function main() {
   const ethParams = calcEthereumTransactionParams({
     gasLimit: '21000010',
-    validUntil: '360001',
+    validUntil: '3600010',
     storageLimit: '640010',
     txFeePerGas,
     storageByteDeposit

--- a/NFT/test/NFT.js
+++ b/NFT/test/NFT.js
@@ -11,7 +11,7 @@ const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 describe("NFT contract", async function () {
         const ethParams = calcEthereumTransactionParams({
                 gasLimit: '21000010',
-                validUntil: '360001',
+                validUntil: '3600010',
                 storageLimit: '640010',
                 txFeePerGas,
                 storageByteDeposit

--- a/NFT/test/loop.js
+++ b/NFT/test/loop.js
@@ -8,7 +8,7 @@ const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
 const loop = async (interval = 2000) => {
   const ethParams = calcEthereumTransactionParams({
     gasLimit: '21000010',
-    validUntil: '360001',
+    validUntil: '3600010',
     storageLimit: '640010',
     txFeePerGas,
     storageByteDeposit

--- a/echo/README.md
+++ b/echo/README.md
@@ -114,7 +114,7 @@ const { expect } = require("chai");
 describe("Echo contract", async function () {
         const ethParams = calcEthereumTransactionParams({
           gasLimit: '2100001',
-          validUntil: '360001',
+          validUntil: '3600010',
           storageLimit: '64001',
           txFeePerGas,
           storageByteDeposit
@@ -219,7 +219,7 @@ With that, our test is ready to be run.
     describe("Echo contract", async function () {
             const ethParams = calcEthereumTransactionParams({
                 gasLimit: '2100001',
-                validUntil: '360001',
+                validUntil: '3600010',
                 storageLimit: '64001',
                 txFeePerGas,
                 storageByteDeposit
@@ -319,7 +319,7 @@ const storageByteDeposit = '100000000000000';
 async function main() {
         const ethParams = calcEthereumTransactionParams({
           gasLimit: '2100001',
-          validUntil: '360001',
+          validUntil: '3600010',
           storageLimit: '64001',
           txFeePerGas,
           storageByteDeposit
@@ -373,7 +373,7 @@ calling `echo()` from instance and outputting the result using `console.log()`:
         async function main() {
                 const ethParams = calcEthereumTransactionParams({
                         gasLimit: '2100001',
-                        validUntil: '360001',
+                        validUntil: '3600010',
                         storageLimit: '64001',
                         txFeePerGas,
                         storageByteDeposit

--- a/echo/scripts/deploy.js
+++ b/echo/scripts/deploy.js
@@ -6,7 +6,7 @@ const storageByteDeposit = '100000000000000';
 async function main() {
   const ethParams = calcEthereumTransactionParams({
     gasLimit: '2100001',
-    validUntil: '360001',
+    validUntil: '3600010',
     storageLimit: '64001',
     txFeePerGas,
     storageByteDeposit

--- a/echo/test/Echo.js
+++ b/echo/test/Echo.js
@@ -7,7 +7,7 @@ const storageByteDeposit = '100000000000000';
 describe("Echo contract", async function () {
         const ethParams = calcEthereumTransactionParams({
           gasLimit: '2100001',
-          validUntil: '360001',
+          validUntil: '3600010',
           storageLimit: '64001',
           txFeePerGas,
           storageByteDeposit

--- a/echo/test/loop.js
+++ b/echo/test/loop.js
@@ -8,7 +8,7 @@ const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
 const loop = async (interval = 2000) => {
   const ethParams = calcEthereumTransactionParams({
     gasLimit: '2100001',
-    validUntil: '360001',
+    validUntil: '3600010',
     storageLimit: '64001',
     txFeePerGas,
     storageByteDeposit

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -248,7 +248,7 @@ turn place within the `describe` block:
     it("returns the right value after the contract is deployed", async function () {
         const ethParams = calcEthereumTransactionParams({
           gasLimit: '2100001',
-          validUntil: '360001',
+          validUntil: '3600010',
           storageLimit: '64001',
           txFeePerGas,
           storageByteDeposit
@@ -282,7 +282,7 @@ With that, our test is ready to be run.
         it("returns the right value after the contract is deployed", async function () {
             const ethParams = calcEthereumTransactionParams({
               gasLimit: '2100001',
-              validUntil: '360001',
+              validUntil: '3600010',
               storageLimit: '64001',
               txFeePerGas,
               storageByteDeposit
@@ -367,7 +367,7 @@ keep track of how many times the function has forced a block generation:
 ```js
   const ethParams = calcEthereumTransactionParams({
     gasLimit: '2100001',
-    validUntil: '360001',
+    validUntil: '3600010',
     storageLimit: '64001',
     txFeePerGas,
     storageByteDeposit
@@ -411,7 +411,7 @@ of times the block generation was forced usiung this script:
     const loop = async (interval = 2000) => {
       const ethParams = calcEthereumTransactionParams({
         gasLimit: '2100001',
-        validUntil: '360001',
+        validUntil: '3600010',
         storageLimit: '64001',
         txFeePerGas,
         storageByteDeposit
@@ -512,7 +512,7 @@ development:
 ```js
   const ethParams = calcEthereumTransactionParams({
     gasLimit: '2100001',
-    validUntil: '360001',
+    validUntil: '3600010',
     storageLimit: '64001',
     txFeePerGas,
     storageByteDeposit
@@ -555,7 +555,7 @@ terminal. We do it by calling `helloWorld()` from instance and outputting the re
     async function main() {
       const ethParams = calcEthereumTransactionParams({
         gasLimit: '2100001',
-        validUntil: '360001',
+        validUntil: '3600010',
         storageLimit: '64001',
         txFeePerGas,
         storageByteDeposit

--- a/hello-world/scripts/deploy.js
+++ b/hello-world/scripts/deploy.js
@@ -6,7 +6,7 @@ const storageByteDeposit = '100000000000000';
 async function main() {
   const ethParams = calcEthereumTransactionParams({
     gasLimit: '2100001',
-    validUntil: '360001',
+    validUntil: '3600010',
     storageLimit: '64001',
     txFeePerGas,
     storageByteDeposit

--- a/hello-world/test/HelloWorld.js
+++ b/hello-world/test/HelloWorld.js
@@ -8,7 +8,7 @@ describe("HelloWorld contract", async function () {
     it("returns the right value after the contract is deployed", async function () {
         const ethParams = calcEthereumTransactionParams({
           gasLimit: '2100001',
-          validUntil: '360001',
+          validUntil: '3600010',
           storageLimit: '64001',
           txFeePerGas,
           storageByteDeposit

--- a/hello-world/test/loop.js
+++ b/hello-world/test/loop.js
@@ -8,7 +8,7 @@ const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
 const loop = async (interval = 2000) => {
   const ethParams = calcEthereumTransactionParams({
     gasLimit: '2100001',
-    validUntil: '360001',
+    validUntil: '3600010',
     storageLimit: '64001',
     txFeePerGas,
     storageByteDeposit

--- a/token/README.md
+++ b/token/README.md
@@ -110,7 +110,7 @@ const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 describe("Token contract", async function () {
         const ethParams = calcEthereumTransactionParams({
                 gasLimit: '2100001',
-                validUntil: '360001',
+                validUntil: '3600010',
                 storageLimit: '64001',
                 txFeePerGas,
                 storageByteDeposit
@@ -526,7 +526,7 @@ With that, our test is ready to be run.
         describe("Token contract", async function () {
                 const ethParams = calcEthereumTransactionParams({
                         gasLimit: '2100001',
-                        validUntil: '360001',
+                        validUntil: '3600010',
                         storageLimit: '64001',
                         txFeePerGas,
                         storageByteDeposit
@@ -871,7 +871,7 @@ console.log()`:
 ```js
   const ethParams = calcEthereumTransactionParams({
           gasLimit: '2100001',
-          validUntil: '360001',
+          validUntil: '3600010',
           storageLimit: '64001',
           txFeePerGas,
           storageByteDeposit
@@ -910,7 +910,7 @@ console.log()`:
         async function main() {
                 const ethParams = calcEthereumTransactionParams({
                         gasLimit: '2100001',
-                        validUntil: '360001',
+                        validUntil: '3600010',
                         storageLimit: '64001',
                         txFeePerGas,
                         storageByteDeposit

--- a/token/scripts/deploy.js
+++ b/token/scripts/deploy.js
@@ -6,7 +6,7 @@ const storageByteDeposit = '100000000000000';
 async function main() {
   const ethParams = calcEthereumTransactionParams({
           gasLimit: '2100001',
-          validUntil: '360001',
+          validUntil: '3600010',
           storageLimit: '64001',
           txFeePerGas,
           storageByteDeposit

--- a/token/test/Token.js
+++ b/token/test/Token.js
@@ -11,7 +11,7 @@ const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 describe("Token contract", async function () {
         const ethParams = calcEthereumTransactionParams({
                 gasLimit: '2100001',
-                validUntil: '360001',
+                validUntil: '3600010',
                 storageLimit: '64001',
                 txFeePerGas,
                 storageByteDeposit

--- a/token/test/loop.js
+++ b/token/test/loop.js
@@ -8,7 +8,7 @@ const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
 const loop = async (interval = 2000) => {
   const ethParams = calcEthereumTransactionParams({
     gasLimit: '2100001',
-    validUntil: '360001',
+    validUntil: '3600010',
     storageLimit: '64001',
     txFeePerGas,
     storageByteDeposit


### PR DESCRIPTION
As the public test network is growing, it outgrew the `validUntil` values
in the scripts, which meant that the scripts could no longer be run with
the public development network. The values were padded with a 0, so this
should bridge them for a while.