### PR TITLE
Redesign loop

### DIFF
--- a/DEX/README.md
+++ b/DEX/README.md
@@ -63,25 +63,21 @@ describe("DEX contract", function () {
 ```
 
 To prepare for the testing, we have to define the global variables, `instance`, `ACAinstance`,
-`AUSDinstance`, `deployer`, `user`, `deployerAddress` and `userAddress`. The `instance` will store
-the predeployed DEX smart contract instance, the `ACAinstance` and `AUSDinstance` variables will
-store their respective ERC20 predeployed token smart contracts. The `deployer` and `user` will store
-`Signer`s and the `deployerAddress` and `userAddress` will store their respecitve addresses. Let's
-assign these values in the `beforeEach` action:
+`AUSDinstance`, `deployer` and `deployerAddress`. The `instance` will store the predeployed DEX
+smart contract instance, the `ACAinstance` and `AUSDinstance` variables will store their respective
+ERC20 predeployed token smart contracts. The `deployer` will store `Signer` and the
+`deployerAddress` will store its addresses. Let's assign these values in the `beforeEach` action:
 
 ```js
         let instance;
         let ACAinstance;
         let AUSDinstance;
         let deployer;
-        let user;
         let deployerAddress;
-        let userAddress;
 
         beforeEach(async function () {
-                [deployer, user] = await ethers.getSigners();
+                [deployer] = await ethers.getSigners();
                 deployerAddress = await deployer.getAddress();
-                userAddress = await user.getAddress();
                 instance = new Contract(DEX, DEXContract.abi, deployer);
                 ACAinstance = new Contract(ACA, TokenContract.abi, deployer);
                 AUSDinstance = new Contract(AUSD, TokenContract.abi, deployer);
@@ -552,14 +548,11 @@ With that, our test is ready to be run.
                 let ACAinstance;
                 let AUSDinstance;
                 let deployer;
-                let user;
                 let deployerAddress;
-                let userAddress;
 
                 beforeEach(async function () {
-                        [deployer, user] = await ethers.getSigners();
+                        [deployer] = await ethers.getSigners();
                         deployerAddress = await deployer.getAddress();
-                        userAddress = await user.getAddress();
                         instance = new Contract(DEX, DEXContract.abi, deployer);
                         ACAinstance = new Contract(ACA, TokenContract.abi, deployer);
                         AUSDinstance = new Contract(AUSD, TokenContract.abi, deployer);

--- a/DEX/package.json
+++ b/DEX/package.json
@@ -20,11 +20,12 @@
     "loop": "hardhat run test/loop.js --network mandala"
   },
   "devDependencies": {
-    "@acala-network/eth-providers": "^2.1.7",
     "@acala-network/contracts": "^4.0.2",
+    "@acala-network/eth-providers": "^2.1.7",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^4.4.0",
+    "@polkadot/api": "^7.9.1",
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.1"

--- a/DEX/test/DEX.js
+++ b/DEX/test/DEX.js
@@ -12,14 +12,11 @@ describe("DEX contract", function () {
         let ACAinstance;
         let AUSDinstance;
         let deployer;
-        let user;
         let deployerAddress;
-        let userAddress;
 
         beforeEach(async function () {
-                [deployer, user] = await ethers.getSigners();
+                [deployer] = await ethers.getSigners();
                 deployerAddress = await deployer.getAddress();
-                userAddress = await user.getAddress();
                 instance = new Contract(DEX, DEXContract.abi, deployer);
                 ACAinstance = new Contract(ACA, TokenContract.abi, deployer);
                 AUSDinstance = new Contract(AUSD, TokenContract.abi, deployer);

--- a/DEX/test/loop.js
+++ b/DEX/test/loop.js
@@ -1,38 +1,20 @@
-const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
-
-const txFeePerGas = '199999946752';
-const storageByteDeposit = '100000000000000';
-
-const DEXcompiled = require("@acala-network/contracts/build/contracts/DEX.json");
+const { ApiPromise, WsProvider } = require('@polkadot/api');
 
 const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
 
 const loop = async (interval = 2000) => {
-  let blockNumber = await ethers.provider.getBlockNumber();
+  const provider = new WsProvider('ws://127.0.0.1:9944');
 
-  const ethParams = calcEthereumTransactionParams({
-    gasLimit: '2100001',
-    validUntil: (blockNumber + 100).toString(),
-    storageLimit: '64001',
-    txFeePerGas,
-    storageByteDeposit
-  });
-
-  const [deployer] = await ethers.getSigners();
-
-  console.log('Started the infinite DEX deployment loop!');
+  const api = await ApiPromise.create({ provider });
+  
+  console.log('Started forced block generation loop!')
 
   let count = 0;
 
   while (true) {
     await sleep(interval);
-    const DEX = await ethers.ContractFactory.fromSolidity(DEXcompiled, deployer);
-    await DEX.deploy({
-      gasPrice: ethParams.txGasPrice,
-      gasLimit: ethParams.txGasLimit,
-    });
-
-    console.log(`Current number of DEX instances: ${++count}`);
+    await api.rpc.engine.createBlock(true /* create empty */, true /* finalize it*/);
+    console.log(`Current number of force generated blocks: ${++count}`);
   }
 };
 

--- a/NFT/README.md
+++ b/NFT/README.md
@@ -148,28 +148,20 @@ const storageByteDeposit = '100000000000000';
 const NFTContract = require("../artifacts/contracts/NFT.sol/NFT.json");
 const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-describe("NFT contract", async function () {
-        const blockNumber = await ethers.provider.getBlockNumber();
-      
-        const ethParams = calcEthereumTransactionParams({
-                gasLimit: '21000010',
-                validUntil: (blockNumber + 100).toString(),
-                storageLimit: '640010',
-                txFeePerGas,
-                storageByteDeposit
-        });
+describe("NFT contract", function () {
         
 });
 ```
 
-To prepare for the testing, we have to define four global variables, `NFT`, `instance`, `deployer`,
-`user`, `deployerAddress` and `userAddress`. The `NFT` will be used to store the NFT contract
-factory and the `instance` will store the deployed NFT smart contract. Both `deployer` and `user`
-will store `Signers`. The `deployer` is the account used to deploy the smart contract (and the one
-that will receive the `initialBalance`). The `user` is the account we will be using to transfer the
-tokens to and check the allowance operation. `deployerAddress` and `userAddress` hold the addresses
-of the `deployer` and `user` respecitively. They will be used to avoid repetitiveness in our tests.
-Let's assign them values in the `beforeEach` action:
+To prepare for the testing, we have to define the global variables, `NFT`, `instance`, `deployer`,
+`user`, `deployerAddress`, `userAddress`, `blockNumber` and `ethParams`. The `NFT` will be used to
+store the NFT contract factory and the `instance` will store the deployed NFT smart contract. Both
+`deployer` and `user` will store `Signers`. The `deployer` is the account used to deploy the smart
+contract (and the one that will receive the `initialBalance`). The `user` is the account we will be
+using to transfer the tokens to and check the allowance operation. `deployerAddress` and
+`userAddress` hold the addresses of the `deployer` and `user` respecitively. They will be used to
+avoid repetitiveness in our tests. `blockNumber` and `ethParams` will be used to set the transaction
+parameters of the deploy transaction. Let's assign them values in the `beforeEach` action:
 
 ```js
         let NFT;
@@ -178,8 +170,18 @@ Let's assign them values in the `beforeEach` action:
         let user;
         let deployerAddress;
         let userAddress;
+        let blockNumber;
+        let ethParams;
 
         beforeEach(async function () {
+                blockNumber = await ethers.provider.getBlockNumber();
+                ethParams = calcEthereumTransactionParams({
+                        gasLimit: '21000010',
+                        validUntil: (blockNumber + 100).toString(),
+                        storageLimit: '640010',
+                        txFeePerGas,
+                        storageByteDeposit
+                });
                 [deployer, user] = await ethers.getSigners();
                 deployerAddress = await deployer.getAddress();
                 userAddress = await user.getAddress();
@@ -591,25 +593,25 @@ With that, our test is ready to be run.
         const NFTContract = require("../artifacts/contracts/NFT.sol/NFT.json");
         const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-        describe("NFT contract", async function () {
-                const blockNumber = await ethers.provider.getBlockNumber();
-        
-                const ethParams = calcEthereumTransactionParams({
-                        gasLimit: '21000010',
-                        validUntil: (blockNumber + 100).toString(),
-                        storageLimit: '640010',
-                        txFeePerGas,
-                        storageByteDeposit
-                });
-
+        describe("NFT contract",  function () {
                 let NFT;
                 let instance;
                 let deployer;
                 let user;
                 let deployerAddress;
                 let userAddress;
+                let blockNumber;
+                let ethParams;
 
                 beforeEach(async function () {
+                        blockNumber = await ethers.provider.getBlockNumber();
+                        ethParams = calcEthereumTransactionParams({
+                                gasLimit: '21000010',
+                                validUntil: (blockNumber + 100).toString(),
+                                storageLimit: '640010',
+                                txFeePerGas,
+                                storageByteDeposit
+                        });
                         [deployer, user] = await ethers.getSigners();
                         deployerAddress = await deployer.getAddress();
                         userAddress = await user.getAddress();

--- a/NFT/package.json
+++ b/NFT/package.json
@@ -25,6 +25,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^4.4.0",
+    "@polkadot/api": "^7.9.1",
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.1"

--- a/NFT/test/NFT.js
+++ b/NFT/test/NFT.js
@@ -8,25 +8,25 @@ const storageByteDeposit = '100000000000000';
 const NFTContract = require("../artifacts/contracts/NFT.sol/NFT.json");
 const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-describe("NFT contract", async function () {
-        const blockNumber = await ethers.provider.getBlockNumber();
-      
-        const ethParams = calcEthereumTransactionParams({
-                gasLimit: '21000010',
-                validUntil: (blockNumber + 100).toString(),
-                storageLimit: '640010',
-                txFeePerGas,
-                storageByteDeposit
-        });
-
+describe("NFT contract", function () {
         let NFT;
         let instance;
         let deployer;
         let user;
         let deployerAddress;
         let userAddress;
+        let blockNumber;
+        let ethParams;
 
         beforeEach(async function () {
+                blockNumber = await ethers.provider.getBlockNumber();
+                ethParams = calcEthereumTransactionParams({
+                        gasLimit: '21000010',
+                        validUntil: (blockNumber + 100).toString(),
+                        storageLimit: '640010',
+                        txFeePerGas,
+                        storageByteDeposit
+                });
                 [deployer, user] = await ethers.getSigners();
                 deployerAddress = await deployer.getAddress();
                 userAddress = await user.getAddress();

--- a/NFT/test/loop.js
+++ b/NFT/test/loop.js
@@ -1,34 +1,20 @@
-const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
-
-const txFeePerGas = '199999946752';
-const storageByteDeposit = '100000000000000';
+const { ApiPromise, WsProvider } = require('@polkadot/api');
 
 const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
 
 const loop = async (interval = 2000) => {
-  const blockNumber = await ethers.provider.getBlockNumber();
+  const provider = new WsProvider('ws://127.0.0.1:9944');
 
-  const ethParams = calcEthereumTransactionParams({
-    gasLimit: '21000010',
-    validUntil: (blockNumber + 100).toString(),
-    storageLimit: '640010',
-    txFeePerGas,
-    storageByteDeposit
-  });
-
-  console.log('Started the infinite NFT deployment loop!');
+  const api = await ApiPromise.create({ provider });
+  
+  console.log('Started forced block generation loop!')
 
   let count = 0;
 
   while (true) {
     await sleep(interval);
-    const NFT = await ethers.getContractFactory('NFT');
-    await NFT.deploy({
-      gasPrice: ethParams.txGasPrice,
-      gasLimit: ethParams.txGasLimit,
-    });
-
-    console.log(`Current number of NFT instances: ${++count}`);
+    await api.rpc.engine.createBlock(true /* create empty */, true /* finalize it*/);
+    console.log(`Current number of force generated blocks: ${++count}`);
   }
 };
 

--- a/echo/README.md
+++ b/echo/README.md
@@ -104,36 +104,39 @@ the `artifacts` directory and contain the compiled smart contract.
 
 ## Test
 
-Your test file should be called `Echo.js` and the empty test along with the import statements
-and transaction parameters definition should look like this:
+Your test file should be called `Echo.js` and the empty test along with the import statements should
+look like this:
 
 ```js
 const { expect } = require("chai");
 
 
-describe("Echo contract", async function () {
-        const blockNumber = await ethers.provider.getBlockNumber();
-
-        const ethParams = calcEthereumTransactionParams({
-                gasLimit: '2100001',
-                validUntil: (blockNumber + 100).toString(),
-                storageLimit: '64001',
-                txFeePerGas,
-                storageByteDeposit
-        });
+describe("Echo contract", function () {
 
 });
 ```
 
-To prepare for the testing, we have to define two global variables, `Echo` and `instance`. The
-`Echo` will be used to store the Echo contract factory and the `instance` will store the deployed
-Echo smart contract. Let's assign them values in the `beforeEach` action:
+To prepare for the testing, we have to define four global variables, `Echo`, `instance`,
+`blockNumber` and `ethParams`. The `Echo` will be used to store the Echo contract factory and the
+`instance` will store the deployed Echo smart contract. `ethParams` is used to store the deployment
+transaction configuration and the `blockNumber` is used to dinamically set the `validUntil` value of
+the `ethParams`. Let's assign them values in the `beforeEach` action:
 
 ```js
         let Echo;
         let instance;
+        let blockNumber;
+        let ethParams;
 
         beforeEach(async function () {
+                blockNumber = await ethers.provider.getBlockNumber();
+                ethParams = calcEthereumTransactionParams({
+                        gasLimit: '2100001',
+                        validUntil: (blockNumber + 100).toString(),
+                        storageLimit: '64001',
+                        txFeePerGas,
+                        storageByteDeposit
+                });
                 Echo = await ethers.getContractFactory("Echo");
                 instance = await Echo.deploy({
                         gasPrice: ethParams.txGasPrice,
@@ -213,30 +216,26 @@ With that, our test is ready to be run.
     <summary>Your test/Echo.js should look like this:</summary>
 
     const { expect } = require("chai");
-    const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
 
-    const txFeePerGas = '199999946752';
-    const storageByteDeposit = '100000000000000';
-
-    describe("Echo contract", async function () {
-            const blockNumber = await ethers.provider.getBlockNumber();
-
-            const ethParams = calcEthereumTransactionParams({
-                gasLimit: '2100001',
-                validUntil: (blockNumber + 100).toString(),
-                storageLimit: '64001',
-                txFeePerGas,
-                storageByteDeposit
-            });
-
+    describe("Echo contract", function () {
             let Echo;
             let instance;
+            let blockNumber;
+            let ethParams;
 
             beforeEach(async function () {
+                    blockNumber = await ethers.provider.getBlockNumber();
+                    ethParams = calcEthereumTransactionParams({
+                            gasLimit: '2100001',
+                            validUntil: (blockNumber + 100).toString(),
+                            storageLimit: '64001',
+                            txFeePerGas,
+                            storageByteDeposit
+                    });
                     Echo = await ethers.getContractFactory("Echo");
                     instance = await Echo.deploy({
-                        gasPrice: ethParams.txGasPrice,
-                        gasLimit: ethParams.txGasLimit,
+                            gasPrice: ethParams.txGasPrice,
+                            gasLimit: ethParams.txGasLimit,
                     });
             });
 

--- a/echo/package.json
+++ b/echo/package.json
@@ -24,6 +24,7 @@
     "@acala-network/eth-providers": "^2.1.7",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
+    "@polkadot/api": "^7.9.1",
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.1"

--- a/echo/test/Echo.js
+++ b/echo/test/Echo.js
@@ -4,21 +4,21 @@ const { calcEthereumTransactionParams } = require("@acala-network/eth-providers"
 const txFeePerGas = '199999946752';
 const storageByteDeposit = '100000000000000';
 
-describe("Echo contract", async function () {
-        const blockNumber = await ethers.provider.getBlockNumber();
-      
-        const ethParams = calcEthereumTransactionParams({
-          gasLimit: '2100001',
-          validUntil: (blockNumber + 100).toString(),
-          storageLimit: '64001',
-          txFeePerGas,
-          storageByteDeposit
-        });
-
+describe("Echo contract", function () {
         let Echo;
         let instance;
+        let blockNumber;
+        let ethParams;
 
         beforeEach(async function () {
+                blockNumber = await ethers.provider.getBlockNumber();
+                ethParams = calcEthereumTransactionParams({
+                        gasLimit: '2100001',
+                        validUntil: (blockNumber + 100).toString(),
+                        storageLimit: '64001',
+                        txFeePerGas,
+                        storageByteDeposit
+                });
                 Echo = await ethers.getContractFactory("Echo");
                 instance = await Echo.deploy({
                         gasPrice: ethParams.txGasPrice,

--- a/echo/test/loop.js
+++ b/echo/test/loop.js
@@ -1,34 +1,20 @@
-const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
-
-const txFeePerGas = '199999946752';
-const storageByteDeposit = '100000000000000';
+const { ApiPromise, WsProvider } = require('@polkadot/api');
 
 const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
 
 const loop = async (interval = 2000) => {
-  const blockNumber = await ethers.provider.getBlockNumber();
+  const provider = new WsProvider('ws://127.0.0.1:9944');
 
-  const ethParams = calcEthereumTransactionParams({
-    gasLimit: '2100001',
-    validUntil: (blockNumber + 100).toString(),
-    storageLimit: '64001',
-    txFeePerGas,
-    storageByteDeposit
-  });
-
-  console.log('Started the infinite Echo deployment loop!');
+  const api = await ApiPromise.create({ provider });
+  
+  console.log('Started forced block generation loop!')
 
   let count = 0;
 
   while (true) {
     await sleep(interval);
-    const Echo = await ethers.getContractFactory('Echo');
-    await Echo.deploy({
-      gasPrice: ethParams.txGasPrice,
-      gasLimit: ethParams.txGasLimit,
-    });
-
-    console.log(`Current number of Echo instances: ${++count}`);
+    await api.rpc.engine.createBlock(true /* create empty */, true /* finalize it*/);
+    console.log(`Current number of force generated blocks: ${++count}`);
   }
 };
 

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -23,6 +23,7 @@
     "@acala-network/eth-providers": "^2.1.7",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
+    "@polkadot/api": "^7.9.1",
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.1"

--- a/hello-world/test/HelloWorld.js
+++ b/hello-world/test/HelloWorld.js
@@ -4,7 +4,7 @@ const { calcEthereumTransactionParams } = require("@acala-network/eth-providers"
 const txFeePerGas = '199999946752';
 const storageByteDeposit = '100000000000000';
 
-describe("HelloWorld contract", async function () {
+describe("HelloWorld contract", function () {
     it("returns the right value after the contract is deployed", async function () {
         const blockNumber = await ethers.provider.getBlockNumber();
       

--- a/hello-world/test/loop.js
+++ b/hello-world/test/loop.js
@@ -1,34 +1,20 @@
-const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
-
-const txFeePerGas = '199999946752';
-const storageByteDeposit = '100000000000000';
+const { ApiPromise, WsProvider } = require('@polkadot/api');
 
 const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
 
 const loop = async (interval = 2000) => {
-  const blockNumber = await ethers.provider.getBlockNumber();
+  const provider = new WsProvider('ws://127.0.0.1:9944');
 
-  const ethParams = calcEthereumTransactionParams({
-    gasLimit: '2100001',
-    validUntil: (blockNumber + 100).toString(),
-    storageLimit: '64001',
-    txFeePerGas,
-    storageByteDeposit
-  });
-
-  console.log('Started the infinite HelloWorld deployment loop!');
+  const api = await ApiPromise.create({ provider });
+  
+  console.log('Started forced block generation loop!')
 
   let count = 0;
 
   while (true) {
     await sleep(interval);
-    const HelloWorld = await ethers.getContractFactory('HelloWorld');
-    await HelloWorld.deploy({
-      gasPrice: ethParams.txGasPrice,
-      gasLimit: ethParams.txGasLimit,
-    });
-
-    console.log(`Current number of HelloWorld instances: ${++count}`);
+    await api.rpc.engine.createBlock(true /* create empty */, true /* finalize it*/);
+    console.log(`Current number of force generated blocks: ${++count}`);
   }
 };
 

--- a/precompiled-token/README.md
+++ b/precompiled-token/README.md
@@ -60,7 +60,7 @@ const { ACA } = require("@acala-network/contracts/utils/Address");
 
 const TokenContract = require("@acala-network/contracts/build/contracts/Token.json");
 
-describe("PrecompiledToken contract", async function () {
+describe("PrecompiledToken contract", function () {
 
 });
 ```
@@ -127,7 +127,7 @@ With that, our test is ready to be run.
 
         const TokenContract = require("@acala-network/contracts/build/contracts/Token.json");
 
-        describe("PrecompiledToken contract", async function () {
+        describe("PrecompiledToken contract", function () {
                 let instance;
                 let deployer;
 

--- a/precompiled-token/package.json
+++ b/precompiled-token/package.json
@@ -23,6 +23,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^4.4.0",
+    "@polkadot/api": "^7.9.1",
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.1"

--- a/precompiled-token/test/PrecompiledToken.js
+++ b/precompiled-token/test/PrecompiledToken.js
@@ -4,7 +4,7 @@ const { ACA } = require("@acala-network/contracts/utils/Address");
 
 const TokenContract = require("@acala-network/contracts/build/contracts/Token.json");
 
-describe("PrecompiledToken contract", async function () {
+describe("PrecompiledToken contract", function () {
         let instance;
         let deployer;
 

--- a/precompiled-token/test/loop.js
+++ b/precompiled-token/test/loop.js
@@ -1,16 +1,20 @@
+const { ApiPromise, WsProvider } = require('@polkadot/api');
+
 const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
 
 const loop = async (interval = 2000) => {
-  console.log('Started the infinite PrecompiledToken deployment loop!');
+  const provider = new WsProvider('ws://127.0.0.1:9944');
+
+  const api = await ApiPromise.create({ provider });
+  
+  console.log('Started forced block generation loop!')
 
   let count = 0;
 
   while (true) {
     await sleep(interval);
-    const PrecompiledToken = await ethers.getContractFactory('PrecompiledToken');
-    await PrecompiledToken.deploy(1234567890);
-
-    console.log(`Current number of PrecompiledToken instances: ${++count}`);
+    await api.rpc.engine.createBlock(true /* create empty */, true /* finalize it*/);
+    console.log(`Current number of force generated blocks: ${++count}`);
   }
 };
 

--- a/token/README.md
+++ b/token/README.md
@@ -107,28 +107,20 @@ const storageByteDeposit = '100000000000000';
 const TokenContract = require("../artifacts/contracts/Token.sol/Token.json");
 const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-describe("Token contract", async function () {
-        const blockNumber = await ethers.provider.getBlockNumber();
-      
-        const ethParams = calcEthereumTransactionParams({
-                gasLimit: '2100001',
-                validUntil: (blockNumber + 100).toString(),
-                storageLimit: '64001',
-                txFeePerGas,
-                storageByteDeposit
-        });
+describe("Token contract", function () {
 
 });
 ```
 
-To prepare for the testing, we have to define four global variables, `Token`, `instance`,
-`deployer`, `user`, `deployerAddress` and `userAddress`. The `Token` will be used to store the Token
-contract factory and the `instance` will store the deployed Token smart contract. Both `deployer`
-and `user` will store `Signers`. The `deployer` is the account used to deploy the smart contract 
-(and the one that will receive the `initialBalance`). The `user` is the account we will be using to
-transfer the tokens to and check the allowance operation. `deployerAddress` and `userAddress` hold
-the addresses of the `deployer` and `user` respecitively. They will be used to avoid repetitiveness
-in our tests. Let's assign them values in the `beforeEach` action:
+To prepare for the testing, we have to define global variables, `Token`, `instance`, `deployer`,
+`user`, `deployerAddress`, `userAddress`, `blockNumber` and `ethParams`. The `Token` will be used to
+store the Token contract factory and the `instance` will store the deployed Token smart contract.
+Both `deployer` and `user` will store `Signers`. The `deployer` is the account used to deploy the
+smart contract (and the one that will receive the `initialBalance`). The `user` is the account we
+will be using to transfer the tokens to and check the allowance operation. `deployerAddress` and
+`userAddress` hold the addresses of the `deployer` and `user` respecitively. They will be used to
+avoid repetitiveness in our tests. `blockNumber` and `ethParams` are used to set the transaction
+parameters of the deployment transaction.Let's assign them values in the `beforeEach` action:
 
 ```js
         let Token;
@@ -137,8 +129,22 @@ in our tests. Let's assign them values in the `beforeEach` action:
         let user;
         let deployerAddress;
         let userAddress;
+        let blockNumber;
+        let ethParams;
 
         beforeEach(async function () {
+                blockNumber = await ethers.provider.getBlockNumber();
+      
+                ethParams = calcEthereumTransactionParams({
+                        gasLimit: '2100001',
+                        validUntil: (blockNumber + 100).toString(),
+                        storageLimit: '64001',
+                        txFeePerGas,
+                        storageByteDeposit,
+                        type: 0x60,
+                        tip: "1",
+                        accessList: []
+                });
                 [deployer, user] = await ethers.getSigners();
                 deployerAddress = await deployer.getAddress();
                 userAddress = await user.getAddress();
@@ -147,7 +153,7 @@ in our tests. Let's assign them values in the `beforeEach` action:
                         1234567890,
                         {
                                 gasPrice: ethParams.txGasPrice,
-                                gasLimit: ethParams.txGasLimit,
+                                gasLimit: ethParams.txGasLimit
                         }
                 );
         });
@@ -525,25 +531,29 @@ With that, our test is ready to be run.
         const TokenContract = require("../artifacts/contracts/Token.sol/Token.json");
         const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-        describe("Token contract", async function () {
-                const blockNumber = await ethers.provider.getBlockNumber();
-        
-                const ethParams = calcEthereumTransactionParams({
-                        gasLimit: '2100001',
-                        validUntil: (blockNumber + 100).toString(),
-                        storageLimit: '64001',
-                        txFeePerGas,
-                        storageByteDeposit
-                });
-
+        describe("Token contract", function () {
                 let Token;
                 let instance;
                 let deployer;
                 let user;
                 let deployerAddress;
                 let userAddress;
+                let blockNumber;
+                let ethParams;
 
                 beforeEach(async function () {
+                        blockNumber = await ethers.provider.getBlockNumber();
+        
+                        ethParams = calcEthereumTransactionParams({
+                                gasLimit: '2100001',
+                                validUntil: (blockNumber + 100).toString(),
+                                storageLimit: '64001',
+                                txFeePerGas,
+                                storageByteDeposit,
+                                type: 0x60,
+                                tip: "1",
+                                accessList: []
+                        });
                         [deployer, user] = await ethers.getSigners();
                         deployerAddress = await deployer.getAddress();
                         userAddress = await user.getAddress();
@@ -552,7 +562,7 @@ With that, our test is ready to be run.
                                 1234567890,
                                 {
                                         gasPrice: ethParams.txGasPrice,
-                                        gasLimit: ethParams.txGasLimit,
+                                        gasLimit: ethParams.txGasLimit
                                 }
                         );
                 });

--- a/token/package.json
+++ b/token/package.json
@@ -25,6 +25,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^4.4.0",
+    "@polkadot/api": "^7.9.1",
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.1"

--- a/token/test/Token.js
+++ b/token/test/Token.js
@@ -8,25 +8,29 @@ const storageByteDeposit = '100000000000000';
 const TokenContract = require("../artifacts/contracts/Token.sol/Token.json");
 const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-describe("Token contract", async function () {
-        const blockNumber = await ethers.provider.getBlockNumber();
-      
-        const ethParams = calcEthereumTransactionParams({
-                gasLimit: '2100001',
-                validUntil: (blockNumber + 100).toString(),
-                storageLimit: '64001',
-                txFeePerGas,
-                storageByteDeposit
-        });
-
+describe("Token contract", function () {
         let Token;
         let instance;
         let deployer;
         let user;
         let deployerAddress;
         let userAddress;
+        let blockNumber;
+        let ethParams;
 
         beforeEach(async function () {
+                blockNumber = await ethers.provider.getBlockNumber();
+      
+                ethParams = calcEthereumTransactionParams({
+                        gasLimit: '2100001',
+                        validUntil: (blockNumber + 100).toString(),
+                        storageLimit: '64001',
+                        txFeePerGas,
+                        storageByteDeposit,
+                        type: 0x60,
+                        tip: "1",
+                        accessList: []
+                });
                 [deployer, user] = await ethers.getSigners();
                 deployerAddress = await deployer.getAddress();
                 userAddress = await user.getAddress();
@@ -35,7 +39,7 @@ describe("Token contract", async function () {
                         1234567890,
                         {
                                 gasPrice: ethParams.txGasPrice,
-                                gasLimit: ethParams.txGasLimit,
+                                gasLimit: ethParams.txGasLimit
                         }
                 );
         });
@@ -237,7 +241,7 @@ describe("Token contract", async function () {
                                 it("should revert when tring to transfer more than allowed amount", async function () {
                                         await instance.connect(deployer).approve(userAddress, 100);
                                         await expect(instance.connect(user).transferFrom(deployerAddress, userAddress, 1000)).to
-                                                .be.revertedWith("ERC20: transfer amount exceeds allowance");
+                                                .be.revertedWith("ERC20: insufficient allowance");
                                 });
 
                                 it("should revert when transfering to 0x0 address", async function () {
@@ -254,7 +258,7 @@ describe("Token contract", async function () {
 
                                 it("should revert when trying to transfer from without being given allowance", async function () {
                                         await expect(instance.connect(user).transferFrom(deployerAddress, userAddress, 10)).to
-                                                .be.revertedWith("ERC20: transfer amount exceeds allowance");
+                                                .be.revertedWith("ERC20: insufficient allowance");
                                 });
                         });
                 });

--- a/token/test/loop.js
+++ b/token/test/loop.js
@@ -1,37 +1,20 @@
-const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
-
-const txFeePerGas = '199999946752';
-const storageByteDeposit = '100000000000000';
+const { ApiPromise, WsProvider } = require('@polkadot/api');
 
 const sleep = async time => new Promise((resolve) => setTimeout(resolve, time));
 
 const loop = async (interval = 2000) => {
-  const blockNumber = await ethers.provider.getBlockNumber();
+  const provider = new WsProvider('ws://127.0.0.1:9944');
 
-  const ethParams = calcEthereumTransactionParams({
-    gasLimit: '2100001',
-    validUntil: (blockNumber + 100).toString(),
-    storageLimit: '64001',
-    txFeePerGas,
-    storageByteDeposit
-  });
-
-  console.log('Started the infinite Token deployment loop!');
+  const api = await ApiPromise.create({ provider });
+  
+  console.log('Started forced block generation loop!')
 
   let count = 0;
 
   while (true) {
     await sleep(interval);
-    const Token = await ethers.getContractFactory('Token');
-    await Token.deploy(
-      1234567890,
-      {
-        gasPrice: ethParams.txGasPrice,
-        gasLimit: ethParams.txGasLimit,
-      }
-    );
-
-    console.log(`Current number of Token instances: ${++count}`);
+    await api.rpc.engine.createBlock(true /* create empty */, true /* finalize it*/);
+    console.log(`Current number of force generated blocks: ${++count}`);
   }
 };
 


### PR DESCRIPTION
Loop was redesigned, so that it uses createBlock RPC call in stead of continuously deploying the same smart contract again and again. This way there is no nonce clashes with the tests and scripts, when they are run in parallel.