### PR TITLE
Revert @polkadot/api downgrade

### DIFF
--- a/DEX/package.json
+++ b/DEX/package.json
@@ -25,7 +25,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^4.4.0",
-    "@polkadot/api": "~6.11.1",
+    "@polkadot/api": "^7.9.1",
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.1"

--- a/NFT/package.json
+++ b/NFT/package.json
@@ -25,7 +25,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^4.4.0",
-    "@polkadot/api": "~6.11.1",
+    "@polkadot/api": "^7.9.1",
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.1"

--- a/echo/package.json
+++ b/echo/package.json
@@ -24,7 +24,7 @@
     "@acala-network/eth-providers": "^2.1.7",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
-    "@polkadot/api": "~6.11.1",
+    "@polkadot/api": "^7.9.1",
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.1"

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -23,7 +23,7 @@
     "@acala-network/eth-providers": "^2.1.7",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
-    "@polkadot/api": "~6.11.1",
+    "@polkadot/api": "^7.9.1",
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.1"

--- a/precompiled-token/package.json
+++ b/precompiled-token/package.json
@@ -23,7 +23,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^4.4.0",
-    "@polkadot/api": "~6.11.1",
+    "@polkadot/api": "^7.9.1",
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.1"

--- a/token/package.json
+++ b/token/package.json
@@ -25,7 +25,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^4.4.0",
-    "@polkadot/api": "~6.11.1",
+    "@polkadot/api": "^7.9.1",
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.1"


### PR DESCRIPTION
@polkadot/api downgrade was incompatible with our current loop helpers,
so the downgrade was reverted to ensure the expected behaviour of the
helper.