### PR TITLE
Add support for rich mode

### DIFF
--- a/EVM/README.md
+++ b/EVM/README.md
@@ -35,11 +35,10 @@ predeployed smart contract. The test file in our case is called `EVM.js`. Within
 dependency. We are using `Contract` in stead of `ContractFactory`, because the contract is already
 deployed to the network. The `EVM`, which is an export from the `ADDRESS` utility of
 `@acala-network/contracts` dependency, is imported and it holds the value of the address of the EVM
-smart contract. `txParams` from the `transactionHelper` utility is imported in order to set the
-deploy transaction parameters for our test contract. Additionally we are importing the compiled
-`EVM` smart contract from the `@acala-network/contracts` dependency, which we will use to
-instantiate the smart contract. `Token` precompile is imported from `@acala-network/contracts` so
-that we can deploy it and use it in the tests.
+smart contract. Additionally we are importing the compiled `EVM` smart contract from the
+`@acala-network/contracts` dependency, which we will use to instantiate the smart contract. `Token`
+precompile is imported from `@acala-network/contracts` so that we can deploy it and use it in the
+tests.
 
 The test file with import statements and an empty test should look like this:
 
@@ -47,8 +46,6 @@ The test file with import statements and an empty test should look like this:
 const { expect } = require("chai");
 const { Contract, BigNumber, Wallet } = require("ethers");
 const { EVM } = require("@acala-network/contracts/utils/MandalaAddress");
-
-const { txParams } = require("../utils/transactionHelper");
 
 const EVMContract = require("@acala-network/contracts/build/contracts/EVM.json");
 const TokenContract = require("@acala-network/contracts/build/contracts/Token.json");
@@ -74,16 +71,12 @@ addresses. Let's assign these values in the `beforeEach` action:
         let userAddress;
 
         beforeEach(async function () {
-                const ethParams = await txParams();
                 [deployer, user] = await ethers.getSigners();
                 deployerAddress = await deployer.getAddress();
                 userAddress = await user.getAddress();
                 instance = new Contract(EVM, EVMContract.abi, deployer);
                 const Token = new ethers.ContractFactory(TokenContract.abi, TokenContract.bytecode, deployer);
-                contract = await Token.deploy({
-                        gasPrice: ethParams.txGasPrice,
-                        gasLimit: ethParams.txGasLimit,
-                });
+                contract = await Token.deploy();
         });
 ```
 
@@ -422,8 +415,6 @@ With that, our test is ready to be run.
         const { Contract, BigNumber, Wallet } = require("ethers");
         const { EVM } = require("@acala-network/contracts/utils/MandalaAddress");
 
-        const { txParams } = require("../utils/transactionHelper");
-
         const EVMContract = require("@acala-network/contracts/build/contracts/EVM.json");
         const TokenContract = require("@acala-network/contracts/build/contracts/Token.json");
         const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
@@ -437,16 +428,12 @@ With that, our test is ready to be run.
                 let userAddress;
 
                 beforeEach(async function () {
-                        const ethParams = await txParams();
                         [deployer, user] = await ethers.getSigners();
                         deployerAddress = await deployer.getAddress();
                         userAddress = await user.getAddress();
                         instance = new Contract(EVM, EVMContract.abi, deployer);
                         const Token = new ethers.ContractFactory(TokenContract.abi, TokenContract.bytecode, deployer);
-                        contract = await Token.deploy({
-                                gasPrice: ethParams.txGasPrice,
-                                gasLimit: ethParams.txGasLimit,
-                        });
+                        contract = await Token.deploy();
                 });
 
                 describe("Operation", function () {
@@ -651,47 +638,47 @@ following output:
 yarn test-mandala
 
 
-yarn run v1.22.17
+yarn run v1.22.19
 $ hardhat test test/EVM.js --network mandala
 
 
   EVM contract
     Operation
       newContractExtraBytes()
-        ✓ should return the new contract extra bytes
+        ✔ should return the new contract extra bytes
       storageDepositPerByte()
-        ✓ should return the storage deposit (41ms)
+        ✔ should return the storage deposit
       maintainerOf()
-        ✓ should return the maintainer of the contract
+        ✔ should return the maintainer of the contract
       developerDeposit()
-        ✓ should return the developer deposit
+        ✔ should return the developer deposit
       publicationFee()
-        ✓ should return the publication fee
+        ✔ should return the publication fee
       transferMaintainter()
-        ✓ should return the storage deposit (1478ms)
-        ✓ should emit TransferredMaintainer when maintainer role of the contract is transferred (5495ms)
-        ✓ should revert if the caller is not the maintainer of the contract
-        ✓ should revert if trying to transfer maintainer of 0x0
-        ✓ should revert when trying to mainain maintainer to 0x0 address
+        ✔ should transfer the maintainer of the contract (2234ms)
+        ✔ should emit TransferredMaintainer when maintainer role of the contract is transferred (3235ms)
+        ✔ should revert if the caller is not the maintainer of the contract
+        ✔ should revert if trying to transfer maintainer of 0x0
+        ✔ should revert when trying to transfer maintainer to 0x0 address
       publishContract()
-        ✓ should emit ContractPublished event (5443ms)
-        ✓ should revert when caller is not the maintainer of the contract
-        ✓ should revert when trying to publish 0x0 contract
+        ✔ should emit ContractPublished event (3263ms)
+        ✔ should revert when caller is not the maintainer of the contract
+        ✔ should revert when trying to publish 0x0 contract
       developerStatus()
-        ✓ should return the status of the development account (102ms)
+        ✔ should return the status of the development account (83ms)
       developerDisable()
-        ✓ should disable development mode (1445ms)
-        ✓ should emit DeveloperDisabled (2662ms)
-        ✓ should revert if the development account is not enabled (52ms)
+        ✔ should disable development mode (2227ms)
+        ✔ should emit DeveloperDisabled (5425ms)
+        ✔ should revert if the development account is not enabled (39ms)
       developerEnable()
-        ✓ should enable development mode (1364ms)
-        ✓ should emit DeveloperEnabled event (2747ms)
-        ✓ should revert if the development mode is already enabled
+        ✔ should enable development mode (2235ms)
+        ✔ should emit DeveloperEnabled event (5471ms)
+        ✔ should revert if the development mode is already enabled (39ms)
 
 
-  20 passing (47s)
+  20 passing (1m)
 
-✨  Done in 48.45s.
+✨  Done in 69.30s.
 ```
 
 ## User journey

--- a/EVM/test/EVM.js
+++ b/EVM/test/EVM.js
@@ -2,8 +2,6 @@ const { expect } = require('chai');
 const { Contract, BigNumber, Wallet } = require('ethers');
 const { EVM } = require('@acala-network/contracts/utils/MandalaAddress');
 
-const { txParams } = require('../utils/transactionHelper');
-
 const EVMContract = require('@acala-network/contracts/build/contracts/EVM.json');
 const TokenContract = require('@acala-network/contracts/build/contracts/Token.json');
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
@@ -17,16 +15,12 @@ describe('EVM contract', function () {
   let userAddress;
 
   beforeEach(async function () {
-    const ethParams = await txParams();
     [deployer, user] = await ethers.getSigners();
     deployerAddress = await deployer.getAddress();
     userAddress = await user.getAddress();
     instance = new Contract(EVM, EVMContract.abi, deployer);
     const Token = new ethers.ContractFactory(TokenContract.abi, TokenContract.bytecode, deployer);
-    contract = await Token.deploy({
-      gasPrice: ethParams.txGasPrice,
-      gasLimit: ethParams.txGasLimit
-    });
+    contract = await Token.deploy();
   });
 
   describe('Operation', function () {

--- a/NFT/README.md
+++ b/NFT/README.md
@@ -140,10 +140,6 @@ should look like this:
 ```js
 const { expect, use } = require("chai");
 const { ContractFactory } = require("ethers");
-const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
-
-const txFeePerGas = '199999946752';
-const storageByteDeposit = '100000000000000';
 
 const NFTContract = require("../artifacts/contracts/NFT.sol/NFT.json");
 const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
@@ -154,14 +150,12 @@ describe("NFT contract", function () {
 ```
 
 To prepare for the testing, we have to define the global variables, `NFT`, `instance`, `deployer`,
-`user`, `deployerAddress`, `userAddress`, `blockNumber` and `ethParams`. The `NFT` will be used to
-store the NFT contract factory and the `instance` will store the deployed NFT smart contract. Both
-`deployer` and `user` will store `Signers`. The `deployer` is the account used to deploy the smart
-contract (and the one that will receive the `initialBalance`). The `user` is the account we will be
-using to transfer the tokens to and check the allowance operation. `deployerAddress` and
-`userAddress` hold the addresses of the `deployer` and `user` respecitively. They will be used to
-avoid repetitiveness in our tests. `blockNumber` and `ethParams` will be used to set the transaction
-parameters of the deploy transaction. Let's assign them values in the `beforeEach` action:
+`user`, `deployerAddress` and `userAddress`. The `NFT` will be used to store the NFT contract
+factory and the `instance` will store the deployed NFT smart contract. Both `deployer` and `user`
+will store `Signers`. The `deployer` is the account used to deploy the smart contract (and the one
+that will receive the `initialBalance`). The `user` is the account we will be using to transfer the
+tokens to and check the allowance operation. `deployerAddress` and `userAddress` hold the addresses
+of the `deployer` and `user` respecitively. Let's assign them values in the `beforeEach` action:
 
 ```js
         let NFT;
@@ -170,26 +164,13 @@ parameters of the deploy transaction. Let's assign them values in the `beforeEac
         let user;
         let deployerAddress;
         let userAddress;
-        let blockNumber;
-        let ethParams;
 
         beforeEach(async function () {
-                blockNumber = await ethers.provider.getBlockNumber();
-                ethParams = calcEthereumTransactionParams({
-                        gasLimit: '21000010',
-                        validUntil: (blockNumber + 100).toString(),
-                        storageLimit: '640010',
-                        txFeePerGas,
-                        storageByteDeposit
-                });
                 [deployer, user] = await ethers.getSigners();
                 deployerAddress = await deployer.getAddress();
                 userAddress = await user.getAddress();
                 NFT = new ContractFactory(NFTContract.abi, NFTContract.bytecode, deployer);
-                instance = await NFT.deploy({
-                        gasPrice: ethParams.txGasPrice,
-                        gasLimit: ethParams.txGasLimit,
-                });
+                instance = await NFT.deploy();
         });
 ```
 
@@ -585,10 +566,6 @@ With that, our test is ready to be run.
 
         const { expect, use } = require('chai');
         const { ContractFactory } = require('ethers');
-        const { calcEthereumTransactionParams } = require('@acala-network/eth-providers');
-
-        const txFeePerGas = '199999946752';
-        const storageByteDeposit = '100000000000000';
 
         const NFTContract = require('../artifacts/contracts/NFT.sol/NFT.json');
         const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
@@ -600,26 +577,13 @@ With that, our test is ready to be run.
                 let user;
                 let deployerAddress;
                 let userAddress;
-                let blockNumber;
-                let ethParams;
 
                 beforeEach(async function () {
-                        blockNumber = await ethers.provider.getBlockNumber();
-                        ethParams = calcEthereumTransactionParams({
-                                gasLimit: '21000010',
-                                validUntil: (blockNumber + 100).toString(),
-                                storageLimit: '640010',
-                                txFeePerGas,
-                                storageByteDeposit
-                        });
                         [deployer, user] = await ethers.getSigners();
                         deployerAddress = await deployer.getAddress();
                         userAddress = await user.getAddress();
                         NFT = new ContractFactory(NFTContract.abi, NFTContract.bytecode, deployer);
-                        instance = await NFT.deploy({
-                                gasPrice: ethParams.txGasPrice,
-                                gasLimit: ethParams.txGasLimit
-                        });
+                        instance = await NFT.deploy();
                 });
 
                 describe('Deployment', function () {
@@ -881,60 +845,59 @@ With that, our test is ready to be run.
 
 </details>
 
-When you run the test with (for example) `yarn test`, your tests should pass with the
+When you run the test with (for example) `yarn test-mandala`, your tests should pass with the
 following output:
 
 ```shell
-yarn test
+yarn test-mandala
 
 
-yarn run v1.22.15
-warning ../../../../../package.json: No license field
-$ hardhat test
+yarn run v1.22.19
+$ hardhat test test/NFT.js --network mandala
 
 
   NFT contract
     Deployment
-      ✓ should set the correct NFT name
-      ✓ should set the correct NFT symbol
-      ✓ should assign the initial balance of the deployer
-      ✓ should revert when trying to get the balance of the 0x0 address (41ms)
+      ✔ should set the correct NFT name (1105ms)
+      ✔ should set the correct NFT symbol (1114ms)
+      ✔ should assign the initial balance of the deployer (1120ms)
+      ✔ should revert when trying to get the balance of the 0x0 address (1091ms)
     Operation
       minting
-        ✓ should mint token to an address (83ms)
-        ✓ should emit Transfer event (183ms)
-        ✓ should set the expected base URI (173ms)
-        ✓ should set the expected URI (86ms)
-        ✓ should allow user to own multiple tokens (313ms)
-        ✓ should revert when trying to get an URI of an nonexistent token
+        ✔ should mint token to an address (4461ms)
+        ✔ should emit Transfer event (4315ms)
+        ✔ should set the expected base URI (4377ms)
+        ✔ should set the expected URI (4408ms)
+        ✔ should allow user to own multiple tokens (7704ms)
+        ✔ should revert when trying to get an URI of an nonexistent token (1114ms)
       balances and ownerships
-        ✓ should revert when trying to get balance of 0x0 address
-        ✓ should revert when trying to get the owner of a nonexistent token
-        ✓ should return the token owner (147ms)
+        ✔ should revert when trying to get balance of 0x0 address (1104ms)
+        ✔ should revert when trying to get the owner of a nonexistent token (1095ms)
+        ✔ should return the token owner (4349ms)
       approvals
-        ✓ should grant an approval (177ms)
-        ✓ should emit Approval event when granting approval (158ms)
-        ✓ should revert when trying to set token approval to self (138ms)
-        ✓ should revert when trying to grant approval for a token that is someone else's (138ms)
-        ✓ should revert when trying to get an approval of a nonexistent token
-        ✓ should return 0x0 address as approved for a token for which no approval is given (127ms)
-        ✓ sets approval for all
-        ✓ revokes approval for all (139ms)
-        ✓ doesn't reflect operator approval in single token approval (174ms)
-        ✓ should allow operator to grant allowance for a apecific token (194ms)
-        ✓ should emit Approval event when operator grants approval (187ms)
-        ✓ should emit ApprovalForAll event when approving for all
-        ✓ should emit ApprovalForAll event when revoking approval for all (113ms)
+        ✔ should grant an approval (7621ms)
+        ✔ should emit Approval event when granting approval (7647ms)
+        ✔ should revert when trying to set token approval to self (4418ms)
+        ✔ should revert when trying to grant approval for a token that is someone else's (4374ms)
+        ✔ should revert when trying to get an approval of a nonexistent token (1112ms)
+        ✔ should return 0x0 address as approved for a token for which no approval is given (4354ms)
+        ✔ sets approval for all (4379ms)
+        ✔ revokes approval for all (7628ms)
+        ✔ doesn't reflect operator approval in single token approval (7643ms)
+        ✔ should allow operator to grant allowance for a apecific token (10946ms)
+        ✔ should emit Approval event when operator grants approval (10918ms)
+        ✔ should emit ApprovalForAll event when approving for all (4327ms)
+        ✔ should emit ApprovalForAll event when revoking approval for all (7552ms)
       transfers
-        ✓ should transfer the token (267ms)
-        ✓ should emit Transfer event (246ms)
-        ✓ should allow transfer of the tokens if the allowance is given (271ms)
-        ✓ should reset the allowance after the token is transferred (266ms)
+        ✔ should transfer the token (7649ms)
+        ✔ should emit Transfer event (7593ms)
+        ✔ should allow transfer of the tokens if the allowance is given (10863ms)
+        ✔ should reset the allowance after the token is transferred (10935ms)
 
 
-  30 passing (7s)
+  30 passing (4m)
 
-✨  Done in 8.28s.
+✨  Done in 226.21s.
 ```
 
 ## Deploy script

--- a/NFT/test/NFT.js
+++ b/NFT/test/NFT.js
@@ -1,9 +1,5 @@
 const { expect, use } = require('chai');
 const { ContractFactory } = require('ethers');
-const { calcEthereumTransactionParams } = require('@acala-network/eth-providers');
-
-const txFeePerGas = '199999946752';
-const storageByteDeposit = '100000000000000';
 
 const NFTContract = require('../artifacts/contracts/NFT.sol/NFT.json');
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
@@ -15,26 +11,13 @@ describe('NFT contract', function () {
   let user;
   let deployerAddress;
   let userAddress;
-  let blockNumber;
-  let ethParams;
 
   beforeEach(async function () {
-    blockNumber = await ethers.provider.getBlockNumber();
-    ethParams = calcEthereumTransactionParams({
-      gasLimit: '21000010',
-      validUntil: (blockNumber + 100).toString(),
-      storageLimit: '640010',
-      txFeePerGas,
-      storageByteDeposit
-    });
     [deployer, user] = await ethers.getSigners();
     deployerAddress = await deployer.getAddress();
     userAddress = await user.getAddress();
     NFT = new ContractFactory(NFTContract.abi, NFTContract.bytecode, deployer);
-    instance = await NFT.deploy({
-      gasPrice: ethParams.txGasPrice,
-      gasLimit: ethParams.txGasLimit
-    });
+    instance = await NFT.deploy();
   });
 
   describe('Deployment', function () {

--- a/advanced-escrow/README.md
+++ b/advanced-escrow/README.md
@@ -711,7 +711,7 @@ and add our own test instead:
 rm test/sample-test.js && touch test/AdvancedEscrow.js
 ```
 
-At the beginning of the file, we will be importing all of the constants and methods that we will require to successfully run the tests. The predeploy smart contract addresses are imported from `@acala-network/contracts` `ADDRESS` utility. We wil be using `chai`'s `expect` and `ethers`' `Contract`, `ContractFactory` and `BigNumber`. To be able to deploy the smart contract for testing, we have to import `txParams` that we added to the `transactionHelper` utility before. We also require the compiled artifacts of the smart contracts that we will be using within the test. This is why we assign them to the `AdvancedEscrowContract`, `TokenContract` and `DEXContract` constants. In order to be able to test the block based deadlines, we need the ability to force the block generation within tests. While we could use the `loop` helper utility, we need to have reliable tests that don't fail if `loop` is not running. For this reason, we import the `ApiPromise` and `WsProvider` from `@polkadot/api`. As initating the `ApiPromise` generates a lot of output, our test output wolud get very messy if we didn't silence it. To do this we use the `console.mute` dependency, that we have to add to the project by using:
+At the beginning of the file, we will be importing all of the constants and methods that we will require to successfully run the tests. The predeploy smart contract addresses are imported from `@acala-network/contracts` `ADDRESS` utility. We wil be using `chai`'s `expect` and `ethers`' `Contract`, `ContractFactory` and `BigNumber`. We also require the compiled artifacts of the smart contracts that we will be using within the test. This is why we assign them to the `AdvancedEscrowContract`, `TokenContract` and `DEXContract` constants. In order to be able to test the block based deadlines, we need the ability to force the block generation within tests. While we could use the `loop` helper utility, we need to have reliable tests that don't fail if `loop` is not running. For this reason, we import the `ApiPromise` and `WsProvider` from `@polkadot/api`. As initating the `ApiPromise` generates a lot of output, our test output wolud get very messy if we didn't silence it. To do this we use the `console.mute` dependency, that we have to add to the project by using:
 
 ```shell
 yarn add --dev console.mute
@@ -724,7 +724,6 @@ const { ACA, AUSD, DEX, DOT } = require('@acala-network/contracts/utils/MandalaA
 const { expect } = require("chai");
 const { Contract, ContractFactory, BigNumber } = require("ethers");
 
-const { txParams } = require("../utils/transactionHelper");
 const AdvancedEscrowContract = require("../artifacts/contracts/AdvancedEscrow.sol/AdvancedEscrow.json");
 const TokenContract = require("@acala-network/contracts/build/contracts/Token.json");
 const DEXContract = require("@acala-network/contracts/build/contracts/DEX.json")
@@ -741,7 +740,7 @@ describe("AdvancedEscrow contract", function () {
 });
 ```
 
-To setup for each of the test examples we define the `AdvancedEscrow` variable that will hold the contract factory for our smart contract. The `instance` variable will hold the instance of the smart contract that we will be testing against and the `ACAinstance`, `AUSDinstance`, `DOTinstance` and `DEXinstance` hold the instances of the predeployed smart contracts. The `deployer` and `user` hold the Signers and `deployerAddress` and `userAddress` variables hold the addresses of these signers. `ethParams` variable holds the transaction values required for the deployment transaction. Finally the `api` variable holds the `ApiPromise`, which we will use to force the generation of blocks. As creation of `ApiPromise` generates a lot of console output, especially when being run before each of the test examples. This is why we have to mute the console output before we create it and resume it after, to keep the expected behaviour of the console. All of the values are assigned in the `beforeEach` action:
+To setup for each of the test examples we define the `AdvancedEscrow` variable that will hold the contract factory for our smart contract. The `instance` variable will hold the instance of the smart contract that we will be testing against and the `ACAinstance`, `AUSDinstance`, `DOTinstance` and `DEXinstance` hold the instances of the predeployed smart contracts. The `deployer` and `user` hold the Signers and `deployerAddress` and `userAddress` variables hold the addresses of these signers. Finally the `api` variable holds the `ApiPromise`, which we will use to force the generation of blocks. As creation of `ApiPromise` generates a lot of console output, especially when being run before each of the test examples. This is why we have to mute the console output before we create it and resume it after, to keep the expected behaviour of the console. All of the values are assigned in the `beforeEach` action:
 
 ```javascript
   let AdvancedEscrow;
@@ -754,7 +753,6 @@ To setup for each of the test examples we define the `AdvancedEscrow` variable t
   let user;
   let deployerAddress;
   let userAddress;
-  let ethParams;
   let api;
 
   beforeEach(async function () {
@@ -762,11 +760,7 @@ To setup for each of the test examples we define the `AdvancedEscrow` variable t
     deployerAddress = await deployer.getAddress();
     userAddress = await user.getAddress();
     AdvancedEscrow = new ContractFactory(AdvancedEscrowContract.abi, AdvancedEscrowContract.bytecode, deployer);
-    ethParams = await txParams();
-    instance = await AdvancedEscrow.deploy({
-      gasPrice: ethParams.txGasPrice,
-      gasLimit: ethParams.txGasLimit,
-    });
+    instance = await AdvancedEscrow.deploy();
     await instance.deployed();
     ACAinstance = new Contract(ACA, TokenContract.abi, deployer);
     AUSDinstance = new Contract(AUSD, TokenContract.abi, deployer);
@@ -1045,7 +1039,6 @@ This concludes our test.
     const { expect } = require("chai");
     const { Contract, ContractFactory, BigNumber } = require("ethers");
 
-    const { txParams } = require("../utils/transactionHelper");
     const AdvancedEscrowContract = require("../artifacts/contracts/AdvancedEscrow.sol/AdvancedEscrow.json");
     const TokenContract = require("@acala-network/contracts/build/contracts/Token.json");
     const DEXContract = require("@acala-network/contracts/build/contracts/DEX.json")
@@ -1068,7 +1061,6 @@ This concludes our test.
         let user;
         let deployerAddress;
         let userAddress;
-        let ethParams;
         let api;
 
         beforeEach(async function () {
@@ -1076,11 +1068,7 @@ This concludes our test.
             deployerAddress = await deployer.getAddress();
             userAddress = await user.getAddress();
             AdvancedEscrow = new ContractFactory(AdvancedEscrowContract.abi, AdvancedEscrowContract.bytecode, deployer);
-            ethParams = await txParams();
-            instance = await AdvancedEscrow.deploy({
-                gasPrice: ethParams.txGasPrice,
-                gasLimit: ethParams.txGasLimit,
-            });
+            instance = await AdvancedEscrow.deploy();
             await instance.deployed();
             ACAinstance = new Contract(ACA, TokenContract.abi, deployer);
             AUSDinstance = new Contract(AUSD, TokenContract.abi, deployer);
@@ -1323,41 +1311,42 @@ As our test is ready to be run, we have to add the scripts to be able to run the
     "test-mandala:pubDev": "hardhat test test/AdvancedEscrow.js --network mandalaPubDev"
 ```
 
-Running the tests with `test-mandala` should give you the following output:
+Running the tests with `yarn test-mandala` should give you the following output:
 
 ```shell
 yarn test-mandala
 
 
-yarn run v1.22.18
+yarn run v1.22.19
 $ hardhat test test/AdvancedEscrow.js --network mandala
+
 
   AdvancedEscrow contract
     Deployment
       ✔ should set the initial number of escrows to 0
     Operation
       ✔ should revert when beneficiary is 0x0
-      ✔ should revert when beneficiary is 0x0
+      ✔ should revert when ingress token is 0x0
       ✔ should revert when period is 0
-      ✔ should revert when balance of the contract is lower than ingressValue
-      ✔ should initate escrow and emit EscrowUpdate when initating escrow (670ms)
-      ✔ should set the values of current escrow when initiating the escrow (788ms)
-      ✔ should revert when initiating a new escrow when there is a preexiting active escrow (839ms)
-      ✔ should revert when trying to set the egress token after the escrow has already been completed (826ms)
-      ✔ should revert when trying to set the egress token while not being the beneficiary (680ms)
-      ✔ should update the egress token (1055ms)
-      ✔ should revert when trying to complete an already completed escrow (880ms)
-      ✔ should revert when trying to complete an escrow when not being the initiator (724ms)
-      ✔ should pay out the escrow in AUSD if no egress token is set (995ms)
-      ✔ should pay out the escrow in set token when egress token is set (1474ms)
-      ✔ should not pay out the escrow in set AUSD when egress token is set (1228ms)
-      ✔ should emit EscrowUpdate when escrow is completed (1175ms)
-      ✔ should automatically complete the escrow when given number of blocks has passed (886ms)
+      ✔ should revert when balance of the contract is lower than ingressValue (49ms)
+      ✔ should initate escrow and emit EscrowUpdate when initating escrow (6650ms)
+      ✔ should set the values of current escrow when initiating the escrow (5670ms)
+      ✔ should revert when initiating a new escrow when there is a preexiting active escrow (6686ms)
+      ✔ should revert when trying to set the egress token after the escrow has already been completed (6741ms)
+      ✔ should revert when trying to set the egress token while not being the beneficiary (6678ms)
+      ✔ should update the egress token (8910ms)
+      ✔ should revert when trying to complete an already completed escrow (6752ms)
+      ✔ should revert when trying to complete an escrow when not being the initiator (6676ms)
+      ✔ should pay out the escrow in AUSD if no egress token is set (8906ms)
+      ✔ should pay out the escrow in set token when egress token is set (12301ms)
+      ✔ should not pay out the escrow in set AUSD when egress token is set (12176ms)
+      ✔ should emit EscrowUpdate when escrow is completed (9930ms)
+      ✔ should automatically complete the escrow when given number of blocks has passed (5675ms)
 
 
-  18 passing (23s)
+  18 passing (3m)
 
-✨  Done in 24.07s.
+✨  Done in 170.22s.
 ```
 
 ## User journey

--- a/advanced-escrow/test/AdvancedEscrow.js
+++ b/advanced-escrow/test/AdvancedEscrow.js
@@ -2,7 +2,6 @@ const { ACA, AUSD, DEX, DOT } = require('@acala-network/contracts/utils/MandalaA
 const { expect } = require('chai');
 const { Contract, ContractFactory, BigNumber } = require('ethers');
 
-const { txParams } = require('../utils/transactionHelper');
 const AdvancedEscrowContract = require('../artifacts/contracts/AdvancedEscrow.sol/AdvancedEscrow.json');
 const TokenContract = require('@acala-network/contracts/build/contracts/Token.json');
 const DEXContract = require('@acala-network/contracts/build/contracts/DEX.json')
@@ -25,7 +24,6 @@ describe('AdvancedEscrow contract', function () {
   let user;
   let deployerAddress;
   let userAddress;
-  let ethParams;
   let api;
 
   beforeEach(async function () {
@@ -33,11 +31,7 @@ describe('AdvancedEscrow contract', function () {
     deployerAddress = await deployer.getAddress();
     userAddress = await user.getAddress();
     AdvancedEscrow = new ContractFactory(AdvancedEscrowContract.abi, AdvancedEscrowContract.bytecode, deployer);
-    ethParams = await txParams();
-    instance = await AdvancedEscrow.deploy({
-      gasPrice: ethParams.txGasPrice,
-      gasLimit: ethParams.txGasLimit,
-    });
+    instance = await AdvancedEscrow.deploy();
     await instance.deployed();
     ACAinstance = new Contract(ACA, TokenContract.abi, deployer);
     AUSDinstance = new Contract(AUSD, TokenContract.abi, deployer);

--- a/echo/README.md
+++ b/echo/README.md
@@ -110,38 +110,22 @@ look like this:
 ```js
 const { expect } = require("chai");
 
-
 describe("Echo contract", function () {
 
 });
 ```
 
-To prepare for the testing, we have to define four global variables, `Echo`, `instance`,
-`blockNumber` and `ethParams`. The `Echo` will be used to store the Echo contract factory and the
-`instance` will store the deployed Echo smart contract. `ethParams` is used to store the deployment
-transaction configuration and the `blockNumber` is used to dinamically set the `validUntil` value of
-the `ethParams`. Let's assign them values in the `beforeEach` action:
+To prepare for the testing, we have to define two global variables, `Echo` and `instance`. The
+`Echo` will be used to store the Echo contract factory and the `instance` will store the deployed
+Echo smart contract. Let's assign them values in the `beforeEach` action:
 
 ```js
         let Echo;
         let instance;
-        let blockNumber;
-        let ethParams;
 
         beforeEach(async function () {
-                blockNumber = await ethers.provider.getBlockNumber();
-                ethParams = calcEthereumTransactionParams({
-                        gasLimit: '2100001',
-                        validUntil: (blockNumber + 100).toString(),
-                        storageLimit: '64001',
-                        txFeePerGas,
-                        storageByteDeposit
-                });
                 Echo = await ethers.getContractFactory("Echo");
-                instance = await Echo.deploy({
-                        gasPrice: ethParams.txGasPrice,
-                        gasLimit: ethParams.txGasLimit,
-                });
+                instance = await Echo.deploy();
         });
 ```
 
@@ -220,23 +204,10 @@ With that, our test is ready to be run.
     describe("Echo contract", function () {
             let Echo;
             let instance;
-            let blockNumber;
-            let ethParams;
 
             beforeEach(async function () {
-                    blockNumber = await ethers.provider.getBlockNumber();
-                    ethParams = calcEthereumTransactionParams({
-                            gasLimit: '2100001',
-                            validUntil: (blockNumber + 100).toString(),
-                            storageLimit: '64001',
-                            txFeePerGas,
-                            storageByteDeposit
-                    });
                     Echo = await ethers.getContractFactory("Echo");
-                    instance = await Echo.deploy({
-                            gasPrice: ethParams.txGasPrice,
-                            gasLimit: ethParams.txGasLimit,
-                    });
+                    instance = await Echo.deploy();
             });
 
             describe("Deployment", function () {
@@ -285,24 +256,23 @@ following output:
 yarn test-mandala
 
 
-yarn run v1.22.15
-warning ../../../../../package.json: No license field
-$ hardhat test --network mandala
+yarn run v1.22.19
+$ hardhat test test/Echo.js --network mandala
 
 
   Echo contract
     Deployment
-      ✓ should set the value of the echo when deploying (8247ms)
+      ✔ should set the value of the echo when deploying (1131ms)
     Operation
-      ✓ should update the echo variable (11574ms)
-      ✓ should emit a NewEcho event (19568ms)
-      ✓ should increment echo counter in the NewEcho event (25942ms)
-      ✓ should return input value (8170ms)
+      ✔ should update the echo variable (3492ms)
+      ✔ should emit a NewEcho event (4425ms)
+      ✔ should increment echo counter in the NewEcho event (6739ms)
+      ✔ should return input value (1158ms)
 
 
-  5 passing (2m)
+  5 passing (29s)
 
-✨  Done in 102.01s.
+✨  Done in 29.11s.
 ```
 
 ## Deploy script

--- a/echo/test/Echo.js
+++ b/echo/test/Echo.js
@@ -1,29 +1,12 @@
 const { expect } = require('chai');
-const { calcEthereumTransactionParams } = require('@acala-network/eth-providers');
-
-const txFeePerGas = '199999946752';
-const storageByteDeposit = '100000000000000';
 
 describe('Echo contract', function () {
   let Echo;
   let instance;
-  let blockNumber;
-  let ethParams;
 
   beforeEach(async function () {
-    blockNumber = await ethers.provider.getBlockNumber();
-    ethParams = calcEthereumTransactionParams({
-      gasLimit: '2100001',
-      validUntil: (blockNumber + 100).toString(),
-      storageLimit: '64001',
-      txFeePerGas,
-      storageByteDeposit
-    });
     Echo = await ethers.getContractFactory('Echo');
-    instance = await Echo.deploy({
-      gasPrice: ethParams.txGasPrice,
-      gasLimit: ethParams.txGasLimit
-    });
+    instance = await Echo.deploy();
   });
 
   describe('Deployment', function () {

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -228,16 +228,17 @@ To add a test, for the smart contract we just created, create a `test` directory
 mkdir test && touch test/HelloWorld.js
 ```
 
-On the first line of the test, import the `expect` from `chai` dependency and
-`calcEthereumTransactionParams` from `eth-providers`. We also set two constants to be used within
-the tests:
+**NOTE: This tutorial assumes that the tests will be run in the
+[overloaded parameters mode](https://evmdocs.acala.network/tooling/rpc-adapter/running-the-rpc-adapter#list-of-options),
+called *rich mode*. It is enabled by passing the *-r* flag when spinning up the RPC adapter.
+
+If you wish to run them without the overloaded mode, please refer to how we pass the deployment
+transaction parameters, like we do in the [Add a script](#add-a-script) section.**
+
+On the first line of the test, import the `expect` from `chai`:
 
 ```js
 const { expect } = require("chai");
-const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
-
-const txFeePerGas = '199999946752';
-const storageByteDeposit = '100000000000000';
 ```
 
 We will be wrapping our test within a `describe` block, so add it below the import statement:
@@ -248,33 +249,18 @@ describe("HelloWorld contract", function () {
 });
 ```
 
-Within the `describe` block, we set the `ethParams` from the `eth-providers` dependency (we won't be
-using all of them, but they are added to the example for reference), then we first get the contract
-factory and then deploy it, passing the transaction parameters within the deployment transaction.
-Once the smart contract is deployed, we can call the `helloWorld()` function, that was automatically
-generated because we made the `helloWorld` variable public and store the result. We compare that
-result to the `Hello World!` string and if everything is in order, our test should pass. Adding
-these steps to the `describe` block, requires us to place them within the `it` block, which we in
-turn place within the `describe` block:
+Within the `describe` block, we first get the contract factory and then deploy it. Once the smart
+contract is deployed, we can call the `helloWorld()` function, that was automatically generated
+because we made the `helloWorld` variable public and store the result. We compare that result to the
+`Hello World!` string and if everything is in order, our test should pass. Adding these steps to the
+`describe` block, requires us to place them within the `it` block, which we in turn place within the
+`describe` block:
 
 ```js
     it("returns the right value after the contract is deployed", async function () {
-        const blockNumber = await ethers.provider.getBlockNumber();
-
-        const ethParams = calcEthereumTransactionParams({
-          gasLimit: '2100001',
-          validUntil: (blockNumber + 100).toString(),
-          storageLimit: '64001',
-          txFeePerGas,
-          storageByteDeposit
-        });
-
         const HelloWorld = await ethers.getContractFactory("HelloWorld");
 
-        const instance = await HelloWorld.deploy({
-            gasPrice: ethParams.txGasPrice,
-            gasLimit: ethParams.txGasLimit,
-        });
+        const instance = await HelloWorld.deploy();
 
         const value = await instance.helloWorld();
 
@@ -288,29 +274,12 @@ With that, our test is ready to be run.
     <summary>Your test/HelloWorld.js should look like this:</summary>
 
     const { expect } = require("chai");
-    const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
-
-    const txFeePerGas = '199999946752';
-    const storageByteDeposit = '100000000000000';
 
     describe("HelloWorld contract", function () {
         it("returns the right value after the contract is deployed", async function () {
-            const blockNumber = await ethers.provider.getBlockNumber();
-          
-            const ethParams = calcEthereumTransactionParams({
-                gasLimit: '2100001',
-                validUntil: (blockNumber + 100).toString(),
-                storageLimit: '64001',
-                txFeePerGas,
-                storageByteDeposit
-            });
-
             const HelloWorld = await ethers.getContractFactory("HelloWorld");
             
-            const instance = await HelloWorld.deploy({
-                gasPrice: ethParams.txGasPrice,
-                gasLimit: ethParams.txGasLimit,
-            });
+            const instance = await HelloWorld.deploy();
 
             const value = await instance.helloWorld();
 
@@ -336,25 +305,24 @@ As you can see, the `test-mandala` and `test-mandala:pubDev` script differ from 
 the `--network` flag which we use to tell Hardhat to use the `mandala` or `mandalaPubDev` network
 configuration from `hardhat.config.js` that we added in the beginning of this tutorial.
 
-When you run the test with (for example) `yarn test`, your tests should pass with the following
-output:
+When you run the test with (for example) `yarn test-mandala`, your tests should pass with the
+following output:
 
 ```shell
-yarn test
+yarn test-mandala
 
 
-yarn run v1.22.15
-warning ../../../../../package.json: No license field
-$ hardhat test
+yarn run v1.22.19
+$ hardhat test test/HelloWorld.js --network mandala
 
 
   HelloWorld contract
-    ✓ returns the right value after the contract is deployed (1558ms)
+    ✔ returns the right value after the contract is deployed (3723ms)
 
 
-  1 passing (2s)
+  1 passing (4s)
 
-✨  Done in 3.53s.
+✨  Done in 4.28s.
 ```
 
 ## Add a script

--- a/hello-world/test/HelloWorld.js
+++ b/hello-world/test/HelloWorld.js
@@ -1,27 +1,10 @@
 const { expect } = require('chai');
-const { calcEthereumTransactionParams } = require('@acala-network/eth-providers');
-
-const txFeePerGas = '199999946752';
-const storageByteDeposit = '100000000000000';
 
 describe('HelloWorld contract', function () {
   it('returns the right value after the contract is deployed', async function () {
-    const blockNumber = await ethers.provider.getBlockNumber();
-
-    const ethParams = calcEthereumTransactionParams({
-      gasLimit: '2100001',
-      validUntil: (blockNumber + 100).toString(),
-      storageLimit: '64001',
-      txFeePerGas,
-      storageByteDeposit
-    });
-
     const HelloWorld = await ethers.getContractFactory('HelloWorld');
 
-    const instance = await HelloWorld.deploy({
-      gasPrice: ethParams.txGasPrice,
-      gasLimit: ethParams.txGasLimit
-    });
+    const instance = await HelloWorld.deploy();
 
     const value = await instance.helloWorld();
 

--- a/token/README.md
+++ b/token/README.md
@@ -99,10 +99,6 @@ should look like this:
 ```js
 const { expect } = require("chai");
 const { ContractFactory } = require("ethers");
-const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
-
-const txFeePerGas = '199999946752';
-const storageByteDeposit = '100000000000000';
 
 const TokenContract = require("../artifacts/contracts/Token.sol/Token.json");
 const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
@@ -113,14 +109,13 @@ describe("Token contract", function () {
 ```
 
 To prepare for the testing, we have to define global variables, `Token`, `instance`, `deployer`,
-`user`, `deployerAddress`, `userAddress`, `blockNumber` and `ethParams`. The `Token` will be used to
-store the Token contract factory and the `instance` will store the deployed Token smart contract.
-Both `deployer` and `user` will store `Signers`. The `deployer` is the account used to deploy the
-smart contract (and the one that will receive the `initialBalance`). The `user` is the account we
-will be using to transfer the tokens to and check the allowance operation. `deployerAddress` and
-`userAddress` hold the addresses of the `deployer` and `user` respecitively. They will be used to
-avoid repetitiveness in our tests. `blockNumber` and `ethParams` are used to set the transaction
-parameters of the deployment transaction.Let's assign them values in the `beforeEach` action:
+`user`, `deployerAddress` and `userAddress`. The `Token` will be used to store the Token contract
+factory and the `instance` will store the deployed Token smart contract. Both `deployer` and `user`
+will store `Signers`. The `deployer` is the account used to deploy the smart contract (and the one
+that will receive the `initialBalance`). The `user` is the account we will be using to transfer the
+tokens to and check the allowance operation. `deployerAddress` and `userAddress` hold the addresses
+of the `deployer` and `user` respecitively. They will be used to avoid repetitiveness in our tests.
+Let's assign them values in the `beforeEach` action:
 
 ```js
         let Token;
@@ -129,30 +124,13 @@ parameters of the deployment transaction.Let's assign them values in the `before
         let user;
         let deployerAddress;
         let userAddress;
-        let blockNumber;
-        let ethParams;
 
         beforeEach(async function () {
-                blockNumber = await ethers.provider.getBlockNumber();
-      
-                ethParams = calcEthereumTransactionParams({
-                        gasLimit: '2100001',
-                        validUntil: (blockNumber + 100).toString(),
-                        storageLimit: '64001',
-                        txFeePerGas,
-                        storageByteDeposit,
-                });
                 [deployer, user] = await ethers.getSigners();
                 deployerAddress = await deployer.getAddress();
                 userAddress = await user.getAddress();
                 Token = new ContractFactory(TokenContract.abi, TokenContract.bytecode, deployer);
-                instance = await Token.deploy(
-                        1234567890,
-                        {
-                                gasPrice: ethParams.txGasPrice,
-                                gasLimit: ethParams.txGasLimit
-                        }
-                );
+                instance = await Token.deploy(1234567890);
         });
 ```
 
@@ -520,10 +498,6 @@ With that, our test is ready to be run.
 
         const { expect } = require("chai");
         const { ContractFactory } = require("ethers");
-        const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
-
-        const txFeePerGas = '199999946752';
-        const storageByteDeposit = '100000000000000';
 
         const TokenContract = require("../artifacts/contracts/Token.sol/Token.json");
         const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
@@ -535,30 +509,13 @@ With that, our test is ready to be run.
                 let user;
                 let deployerAddress;
                 let userAddress;
-                let blockNumber;
-                let ethParams;
 
                 beforeEach(async function () {
-                        blockNumber = await ethers.provider.getBlockNumber();
-        
-                        ethParams = calcEthereumTransactionParams({
-                                gasLimit: '2100001',
-                                validUntil: (blockNumber + 100).toString(),
-                                storageLimit: '64001',
-                                txFeePerGas,
-                                storageByteDeposit,
-                        });
                         [deployer, user] = await ethers.getSigners();
                         deployerAddress = await deployer.getAddress();
                         userAddress = await user.getAddress();
                         Token = new ContractFactory(TokenContract.abi, TokenContract.bytecode, deployer);
-                        instance = await Token.deploy(
-                                1234567890,
-                                {
-                                        gasPrice: ethParams.txGasPrice,
-                                        gasLimit: ethParams.txGasLimit
-                                }
-                        );
+                        instance = await Token.deploy(1234567890);
                 });
 
                 describe("Deployment", function () {
@@ -784,62 +741,61 @@ With that, our test is ready to be run.
 
 </details>
 
-When you run the test with (for example) `yarn test`, your tests should pass with the
+When you run the test with (for example) `yarn test-mandala`, your tests should pass with the
 following output:
 
 ```shell
-yarn test
+yarn test-mandala
 
 
-yarn run v1.22.15
-warning ../../../../../package.json: No license field
-$ hardhat test
+yarn run v1.22.19
+$ hardhat test test/Token.js --network mandala
 
 
   Token contract
     Deployment
-      ✓ should set the correct token name (48ms)
-      ✓ should set the correct token symbol
-      ✓ should set the correct total supply
-      ✓ should assign the initial balance to the deployer
-      ✓ should not assign value to a random address upon deployment
-      ✓ should not assign allowance upond deployment
+      ✔ should set the correct token name (1112ms)
+      ✔ should set the correct token symbol (1091ms)
+      ✔ should set the correct total supply (1100ms)
+      ✔ should assign the initial balance to the deployer (1100ms)
+      ✔ should not assign value to a random address upon deployment (1094ms)
+      ✔ should not assign allowance upon deployment (1116ms)
     Operation
       Transfer
         transfer()
-          ✓ should change the balance of the sender and receiver when transferring token (85ms)
-          ✓ should emit a Transfer event when transfering the token (86ms)
-          ✓ should revert the transfer to a 0x0 address (45ms)
-          ✓ should revert if trying to transfer amount bigger than balance
+          ✔ should change the balance of the sender and receiver when transferring token (4446ms)
+          ✔ should emit a Transfer event when transfering the token (4292ms)
+          ✔ should revert the transfer to a 0x0 address (1107ms)
+          ✔ should revert if trying to transfer amount bigger than balance (1087ms)
       Allowances
         approve()
-          ✓ should grant allowance when the caller has enough funds (55ms)
-          ✓ should grant allowance when the caller has less funds than the ize of the allowance (45ms)
-          ✓ should emit Approval event when calling approve() (45ms)
-          ✓ should revert when trying to give allowance to 0x0 address
+          ✔ should grant allowance when the caller has enough funds (4345ms)
+          ✔ should grant allowance when the caller has less funds than the ize of the allowance (4327ms)
+          ✔ should emit Approval event when calling approve() (4301ms)
+          ✔ should revert when trying to give allowance to 0x0 address (1098ms)
         increaseAllowance()
-          ✓ should allow to increase allowance (96ms)
-          ✓ should allow to increase allowance above the balance (90ms)
-          ✓ should emit Approval event (85ms)
-          ✓ should allow to increase allowance even if none was given before (42ms)
+          ✔ should allow to increase allowance (7623ms)
+          ✔ should allow to increase allowance above the balance (7616ms)
+          ✔ should emit Approval event (7602ms)
+          ✔ should allow to increase allowance even if none was given before (4363ms)
         decreaseAllowance()
-          ✓ should decrease the allowance (95ms)
-          ✓ should emit Approval event (69ms)
-          ✓ should revert when tyring to decrease the allowance below 0 (63ms)
+          ✔ should decrease the allowance (7580ms)
+          ✔ should emit Approval event (7570ms)
+          ✔ should revert when tyring to decrease the allowance below 0 (4375ms)
         transferFrom()
-          ✓ should allow to transfer tokens when allowance is given (99ms)
-          ✓ should emit Transfer event when transferring from another address (81ms)
-          ✓ should emit Approval event when transferring from another address (85ms)
-          ✓ should update the allowance when transferring from another address (93ms)
-          ✓ should revert when tring to transfer more than allowed amount (61ms)
-          ✓ should revert when transfering to 0x0 address (50ms)
-          ✓ should revert when owner doesn't have enough funds (48ms)
-          ✓ should revert when trying to transfer from without being given allowance
+          ✔ should allow to transfer tokens when allowance is given (7689ms)
+          ✔ should emit Transfer event when transferring from another address (7576ms)
+          ✔ should emit Approval event when transferring from another address (7610ms)
+          ✔ should update the allowance when transferring from another address (7604ms)
+          ✔ should revert when tring to transfer more than allowed amount (4306ms)
+          ✔ should revert when transfering to 0x0 address (4387ms)
+          ✔ should revert when owner doesn't have enough funds (4318ms)
+          ✔ should revert when trying to transfer from without being given allowance (1104ms)
 
 
-  29 passing (6s)
+  29 passing (3m)
 
-✨  Done in 8.96s.
+✨  Done in 188.19s.
 ```
 
 ## Deploy script

--- a/token/test/Token.js
+++ b/token/test/Token.js
@@ -1,9 +1,5 @@
 const { expect } = require('chai');
 const { ContractFactory } = require('ethers');
-const { calcEthereumTransactionParams } = require('@acala-network/eth-providers');
-
-const txFeePerGas = '199999946752';
-const storageByteDeposit = '100000000000000';
 
 const TokenContract = require('../artifacts/contracts/Token.sol/Token.json');
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
@@ -15,28 +11,13 @@ describe('Token contract', function () {
   let user;
   let deployerAddress;
   let userAddress;
-  let blockNumber;
-  let ethParams;
-  let tx;
 
   beforeEach(async function () {
-    blockNumber = await ethers.provider.getBlockNumber();
-
-    ethParams = calcEthereumTransactionParams({
-      gasLimit: '2100001',
-      validUntil: (blockNumber + 100).toString(),
-      storageLimit: '64001',
-      txFeePerGas,
-      storageByteDeposit,
-    });
     [deployer, user] = await ethers.getSigners();
     deployerAddress = await deployer.getAddress();
     userAddress = await user.getAddress();
     Token = new ContractFactory(TokenContract.abi, TokenContract.bytecode, deployer);
-    instance = await Token.deploy(1234567890, {
-      gasPrice: ethParams.txGasPrice,
-      gasLimit: ethParams.txGasLimit
-    });
+    instance = await Token.deploy(1234567890);
   });
 
   describe('Deployment', function () {


### PR DESCRIPTION
Updated the tests in the tutorials to use the transaction overload mode (`-r`) and be compatible with being run in the Hardhat's emulated network again.